### PR TITLE
Coveralls fix

### DIFF
--- a/coral-core/build.sbt
+++ b/coral-core/build.sbt
@@ -1,0 +1,1 @@
+scalaVersion := "2.11.4"

--- a/coral-core/src/main/scala/Thing.scala
+++ b/coral-core/src/main/scala/Thing.scala
@@ -1,0 +1,7 @@
+package io.coral.core
+
+object Thing {
+   val streaming = true
+   val fun       = true
+   val jsonapi   = true
+}

--- a/coral-core/src/test/scala/CoralSpec.scala
+++ b/coral-core/src/test/scala/CoralSpec.scala
@@ -1,0 +1,23 @@
+package io.coral.core
+
+import org.scalatest.WordSpec
+
+class CoralSpec extends WordSpec {
+
+  "The Coral API" when {
+    "started" should {
+      "provide  streaming analytics " in {
+        assert(Thing.streaming==true)
+      }
+
+      "be fun and intuitive" in {
+        assert(Thing.fun==true)
+      }
+
+      "provide dataflow capabilities via a json http API" in {
+        assert(Thing.jsonapi==true)
+      }
+
+    }
+  }
+}

--- a/coveralls.rb
+++ b/coveralls.rb
@@ -1,5 +1,0 @@
-#!/usr/bin/env ruby
-
-require 'coveralls'
-
-Coveralls.wear!

--- a/project/build.scala
+++ b/project/build.scala
@@ -31,7 +31,7 @@ object TopLevelBuild extends Build {
   lazy val coral = Project (
     id = Settings.appName,
     base = file (".")
-  ).aggregate(coralApi)
+  ).aggregate(coralCore, coralApi)
 
   lazy val coralApi = Project (
     id = "runtime-api",
@@ -39,4 +39,10 @@ object TopLevelBuild extends Build {
     settings = projectSettings
   ).configs( IntegrationTest ).settings( Defaults.itSettings : _*)
 
+  lazy val coralCore = Project (
+    id = "coral-core",
+    base = file ("coral-core"),
+    settings = projectSettings
+  ).configs( IntegrationTest ).settings( Defaults.itSettings : _*)
 }
+

--- a/project/build.scala
+++ b/project/build.scala
@@ -19,19 +19,24 @@ object Packaging {
 
 object TopLevelBuild extends Build {
 
-  lazy val coral = Project (id = Settings.appName, base = file ("."))
-    .aggregate(runtimeApi)
+  val projectSettings =
+    Settings.buildSettings      ++
+    Packaging.packagingSettings ++
+    Revolver.settings           ++
+    Seq (
+      resolvers           ++= Resolvers.allResolvers,
+      libraryDependencies ++= Dependencies.allDependencies
+    )
 
-  lazy val runtimeApi = Project (
+  lazy val coral = Project (
+    id = Settings.appName,
+    base = file (".")
+  ).aggregate(coralApi)
+
+  lazy val coralApi = Project (
     id = "runtime-api",
     base = file ("runtime-api"),
-    settings = Settings.buildSettings ++
-      Packaging.packagingSettings ++
-      Revolver.settings ++
-      Seq (
-        resolvers ++= Resolvers.allResolvers,
-        libraryDependencies ++= Dependencies.allDependencies
-      )
+    settings = projectSettings
   ).configs( IntegrationTest ).settings( Defaults.itSettings : _*)
-}
 
+}

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-scalaVersion := "2.10.4"
+scalaVersion := "2.10.5"
 
 resolvers ++= Seq(
   "Typesafe Repository" at "http://repo.typesafe.com/typesafe/releases/",
@@ -15,4 +15,8 @@ resolvers += Classpaths.sbtPluginReleases
 
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.0.4")
 
-addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.0.0.BETA1")
+// the following plugin is built from source locally
+// using sources from a sbt-coveralls fork at git://github.com/coral-streaming/sbt-coveralls
+// check project/project/build.scala and http://www.scala-sbt.org/0.13.5/docs/Extending/Plugins.html 1d)
+//
+// addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.0.0.BETA1")

--- a/project/project/build.scala
+++ b/project/project/build.scala
@@ -1,0 +1,8 @@
+import sbt._
+
+object PluginDef extends Build {
+  override lazy val projects = Seq(root)
+  lazy val root = Project("plugins", file(".")).dependsOn( coverallsPlugin )
+  lazy val coverallsPlugin = uri("git://github.com/coral-streaming/sbt-coveralls")
+}
+


### PR DESCRIPTION
This requests reports _logical_ branch names rather than physical id refs.

The fix requires a change on the sbt-coveralls plugin, which has been forked and modified accordingly on the coral-streaming repo https://github.com/coral-streaming/sbt-coveralls and added for build from sources in the current project.

Because of the multi-project build, in order to work properly, the sbt-coveralls requires a minimum of two sub-projects to be tested. Hence the placeholder for coral-core.
