### PR TITLE
Coral expression

### DIFF
--- a/examples/client.py
+++ b/examples/client.py
@@ -6,23 +6,7 @@ import time
 import random 
 
 api = 'http://localhost:8000'
-#api = 'http://natalinobusa-coral.herokuapp.com'
 headers = {'content-type': 'application/json'}
-
-def post(path, payload={}) :
-  r = requests.post(api+path, data=json.dumps(payload), headers=headers)
-  if (r.text):
-    print json.dumps(json.loads(r.text), indent=2)
-
-def get(path) :
-  r = requests.get(api+path, headers=headers)
-  if (r.text):
-    print json.dumps(json.loads(r.text), indent=2)
-
-def delete(path) :
-  r = requests.delete(api+path, headers=headers)
-  if (r.text):
-    print json.dumps(json.loads(r.text), indent=2)
 
 generator = {
   "Amsterdam": {'mu':100, 'sigma':20},
@@ -39,7 +23,3 @@ def randEvent() :
   amount = random.gauss(generator[city]['mu'],generator[city]['sigma'])
   event = {'account':'NL'+str(account), 'amount':amount, 'city':city }
   return event
-
-while(1):
-    post('/api/actors/1/in',randEvent() )
-    time.sleep(0.01)

--- a/examples/example1.py
+++ b/examples/example1.py
@@ -1,10 +1,77 @@
+#!/usr/bin/python
+
 from httpMethods import *
 
-# Create the graph (profiling cities)
-post('/api/actors', {"type":"httpserver"})
-post('/api/actors', {"type":"stats", "params":{"field": "amount"}, "group":{"by":"city"}})
-post('/api/actors', {"type":"zscore",    "params":{"by":"city", "field": "amount","score" : 1.0}})
+import json
+import requests
+import time
+import random
 
-put('/api/actors/1',  {"input":{"trigger":{"in":{"type":"external"}}}})
-put('/api/actors/2',  {"input":{"trigger":{"in":{"type":"actor", "source":1}}}})
-put('/api/actors/3',  {"input":{"trigger":{"in":{"type":"actor", "source":1}},"collect":{"stats":{"type":"actor", "source":2}}}})
+post('/api/actors', { "type": "httpbroadcast"})
+post('/api/actors', { "type": "stats", "params": { "field": "amount"}, "by": "city" })
+post('/api/actors',
+{ "type": "zscore",
+  "params": { "by": "city", "field": "amount", "score": 1.0 },
+  "collect": {
+    "avg": {"value":3.5},
+    "std": {"actor":4444, "field":"standard_dev" },
+    "count": {actor:2, "field":"standard_dev", "group": {"by": "city" }}
+    "city_xxx": { function("city") }
+    "zipcode": { "actor": 42, field:"zipcode", select:"city_xxx" }}
+    },
+   "trigger": 1
+})
+
+post('/api/actors',
+{ "type": "zscore",
+  "params": { ? }, // everything not related to the function, eg timers, group by etc ...
+  "trigger": 1,
+  "input": {
+    "value": { "trigger": "amount" },
+    "score": { "value": 2 },
+    "avg":   { "actor": 2, "by": "city" },
+    "std":   { "actor": 2, "by": "city" },
+    "count": { "actor": 2, "by": "city" }
+  }
+})
+
+post('/api/actors',
+{ "type": "",
+  "params": { ? }, // everything not related to the function, eg timers, group by etc ...
+  "trigger": 1,
+  "input": {
+    "const":{
+      "score":2
+    },
+    "trigger":{
+      "value": "amount",
+    },
+    "collect":{
+      "avg":   {"actor": 2, "by": "city" },
+      "std":   {"actor": 2, "by": "city" },
+      "count": {"actor": 2, "by": "city" }
+  }
+})
+
+
+post('/api/links', { "trigger": { "from": 1, "to": 2 }})
+post('/api/links', { "trigger": { "from": 1, "to": 3 }})
+
+
+generator = {
+  "Amsterdam": {'mu':100, 'sigma':20},
+  "Rotterdam": {'mu':20,  'sigma':20},
+  "DenHaag":   {'mu':500, 'sigma':60},
+  "Utrecht":   {'mu':40,  'sigma':20},
+  "Eindhoven": {'mu':100, 'sigma':10},
+  "Arnhem":    {'mu':200, 'sigma':50}
+}
+
+def randEvent() :
+  account = random.randrange(1000)
+  city = random.choice(generator.keys())
+  amount = random.gauss(generator[city]['mu'],generator[city]['sigma'])
+  event = {'account':'NL'+str(account), 'amount':amount, 'city':city }
+  return event
+
+post('/api/actors/1/in', randEvent())

--- a/examples/example2.py
+++ b/examples/example2.py
@@ -1,6 +1,5 @@
 from httpMethods import *
 
-# Create the graph (profiling tags)
 post('/api/actors', {"type":"httpserver"})
 post('/api/actors', {"type":"stats", "timeout":{"duration":60, "mode":"continue"}, "params":{"field": "amount"}, "group":{"by":"tag"}})
 post('/api/actors', {"type":"zscore",    "params":{"by":"tag", "field": "amount","score" : 6.0}})

--- a/project/dependencies.scala
+++ b/project/dependencies.scala
@@ -32,7 +32,9 @@ object Dependencies {
     // cassandra
     "com.datastax.cassandra" % "cassandra-driver-core" % "2.1.4",
 
-    "org.uncommons.maths" % "uncommons-maths" % "1.2.2a"
+    "org.uncommons.maths" % "uncommons-maths" % "1.2.2a",
+
+    "joda-time" % "joda-time" % "2.7"
   )
 
   val allTestDependencies = Seq(

--- a/runtime-api/src/main/scala/io/coral/actors/CoralActorFactory.scala
+++ b/runtime-api/src/main/scala/io/coral/actors/CoralActorFactory.scala
@@ -33,6 +33,7 @@ object CoralActorFactory {
         case "threshold"  => ThresholdActor(json)
         case "window"     => WindowActor(json)
         case "unlist"     => UnlistActor(json)
+        case "coralscript"=> CoralScriptActor(json)
       }
     } yield props
 

--- a/runtime-api/src/main/scala/io/coral/actors/CoralActorFactory.scala
+++ b/runtime-api/src/main/scala/io/coral/actors/CoralActorFactory.scala
@@ -32,6 +32,7 @@ object CoralActorFactory {
         case "cassandra"  => CassandraActor(json)
         case "threshold"  => ThresholdActor(json)
         case "window"     => WindowActor(json)
+        case "unlist"     => UnlistActor(json)
       }
     } yield props
 

--- a/runtime-api/src/main/scala/io/coral/actors/RuntimeActor.scala
+++ b/runtime-api/src/main/scala/io/coral/actors/RuntimeActor.scala
@@ -13,6 +13,8 @@ class RuntimeActor extends Actor with ActorLogging {
     case CreateActor(json) =>
       val props = CoralActorFactory.getProps(json)
 
+      println("Creating new actor")
+
       val actorId = props map { p =>
         count += 1
         val id = count
@@ -28,6 +30,7 @@ class RuntimeActor extends Actor with ActorLogging {
       count += 1
       sender ! Some(count)
     case ListActors() =>
+      println("LISTING ACTORS!!!")
       sender ! actors.keys.toList
     case Delete(id: Long) =>
       actors.get(id).map { a => actorRefFactory.actorSelection(a) ! PoisonPill }

--- a/runtime-api/src/main/scala/io/coral/actors/transform/CoralScriptActor.scala
+++ b/runtime-api/src/main/scala/io/coral/actors/transform/CoralScriptActor.scala
@@ -1,0 +1,170 @@
+package io.coral.actors.transform
+
+import akka.actor.Props
+import io.coral.actors.CoralActor
+import io.coral.coralscript._
+import org.json4s.JValue
+import org.json4s.JsonAST.{JValue, JObject}
+import org.json4s._
+
+import scala.concurrent.Future
+import scalaz.OptionT
+
+object CoralScriptActor {
+    implicit val formats = org.json4s.DefaultFormats
+
+    def getParams(json: JValue) = {
+        for {
+            script <- (json \ "params" \ "script").extractOpt[String]
+        } yield {
+            script
+        }
+    }
+
+    def apply(json: JValue): Option[Props] = {
+        getParams(json).map(_ => Props(classOf[CoralScriptActor], json))
+    }
+}
+
+class CoralScriptActor(json: JObject) extends CoralActor {
+    def jsonDef = json
+    def state = Map()
+
+    val scriptString = CoralScriptActor.getParams(json).get
+    var script: CoralScript = _
+
+    override def preStart() {
+        script = CoralScriptParser.parse(scriptString)
+    }
+
+    def emit = doNotEmit
+    def timer = notSet
+
+    def trigger = {
+        json: JObject =>
+            /**
+             * The processing flow when a new event comes in is as follows:
+             *    1) Match incoming objects against defined events and check fields
+             *    2) Add the fields of the event to any defined entities, if necessary
+             *    3) Execute any collect statements that need to be re-executed
+             *    4) Recalculate any features if necessary
+             *    5) Recalculate all changed conditions
+             *    6) Find out which triggers are triggered because of updated conditions
+             */
+            val event: EventDeclaration = matchEvent(json)
+            updateEntities(event)
+            recalculateFeatures()
+            val changedConditions = recalculateConditions()
+            val triggeredTriggers = findTriggeredTriggers(changedConditions)
+            executeActions(triggeredTriggers)
+
+            OptionT.some(Future.successful({}))
+    }
+
+    /**
+     * Find out to which event a json object belongs. If no object
+     * is found, throw an exception.
+     * @param json The json object to find the event declaration for.
+     * @return An EventDeclaration if a matching event is found.
+     *         When no matching EventDeclaration is found, an
+     *         IllegalArgumentException is thrown.
+     */
+    def matchEvent(json: JObject): EventDeclaration = {
+        // We assume that an event matches if all fields required
+        // are present in the JSON at root level and that all
+        // values can be converted to their definitions in the event.
+        val typeName = (json \ "datatype").toString
+
+        script.event_defs(typeName) match {
+            case EventDeclaration(_, block) =>
+                block.block.foreach(variable => {
+                    val id = variable.id.toString
+                    val typeSpec = variable.typeSpec
+
+                    json \ id match {
+                        // When the variable is not found in
+                        // the trigger json, something is wrong
+                        case JNull =>
+                            throw new IllegalArgumentException(id.toString)
+                        case valid =>
+                            val value = typeSpec match {
+                                case "Boolean" => false // valid.getAs[Boolean]
+                                case "Int" => 0 // valid.getAs[Int]
+                                case "Float" => 0.0f //valid.getAs[Float]
+                                case "Long" => 0L // valid.getAs[Long]
+                                case "String" => "" //valid.getAs[String]
+                                case "DateTime" => // getDateTime(valid)
+                                case _ => throw new IllegalArgumentException(typeSpec)
+                            }
+                    }
+                })
+
+                // Here all variables are present and are of the
+                // right type that is defined in the event.
+                null
+            case null =>
+                throw new IllegalArgumentException(typeName)
+        }
+    }
+
+    /**
+     * Update any entity that uses information from this event
+     * with the new data. If no entities use information from
+     * this event, do nothing.
+     * @param event The event to use to update the entities.
+     */
+    def updateEntities(event: EventDeclaration) {
+        // Find all entities that uses information from this event.
+        // For each of these entities, find out if it is:
+        //    1) Using a value from an event directly, in this case: just fill it in;
+        //    2) Collects values of this event in an array, in this case
+        //       - Find the entity with the given join key equal to the key of the event
+        //       - Add the item to the array of the entity with the right join key
+        //    3) Uses a collect definition to another actor, in this case:
+        //       ask the actor for the information
+
+    }
+
+    /**
+     * Recalculate features based on incoming information.
+     * This method only recalculates features that are actually changed
+     * by the new information so it needs to find these first.
+     */
+    def recalculateFeatures() {
+
+    }
+
+    /**
+     * Recalculate all conditions that are changed because of the new data.
+     * Find out out which of these conditions are true and which are false.
+     * If a condition is true, it will trigger all triggers that use that condition.
+     * If a condition is false, the triggers will not be triggered.
+     * @return A list of all conditions that evaluate to true.
+     */
+    def recalculateConditions(): List[TriggerCondition] = {
+        List()
+    }
+
+    /**
+     * Based on the list of conditions that are sure to evaluate to true,
+     * give a list of triggers that need to be triggered because of the
+     * changed conditions.
+     * @param changedConditions The conditions that evaluate to true.
+     * @return A list of all triggers of which the actions need to be executed.
+     */
+    def findTriggeredTriggers(changedConditions: List[TriggerCondition]): List[TriggerDeclaration] = {
+        List()
+    }
+
+    /**
+     * Execute the actions that belong to the list of triggers that are
+     * triggered. Multiple actions can belong to the same trigger so
+     * make sure to execute all of them.
+     * @param triggeredTriggers The list of triggers that are triggered.
+     */
+    def executeActions(triggeredTriggers: List[TriggerDeclaration]) {
+        triggeredTriggers.foreach(t => {
+            //t.action.execute()
+        })
+    }
+}

--- a/runtime-api/src/main/scala/io/coral/actors/transform/UnlistActor.scala
+++ b/runtime-api/src/main/scala/io/coral/actors/transform/UnlistActor.scala
@@ -1,0 +1,59 @@
+package io.coral.actors.transform
+
+import akka.actor.{Props, ActorLogging}
+import io.coral.actors.CoralActor
+import org.json4s.JObject
+import org.json4s.JsonAST.JValue
+import spray.client.pipelining._
+import spray.http.{HttpResponse, HttpRequest}
+
+import scala.concurrent.Future
+import scala.util.{Failure, Success}
+import org.json4s._
+import org.json4s.JsonDSL._
+import org.json4s.jackson.JsonMethods._
+import scala.concurrent.duration._
+
+import scalaz.OptionT
+
+object UnlistActor {
+    implicit val formats = org.json4s.DefaultFormats
+
+    def getParams(json: JValue) = {
+        for {
+            field <- (json \ "params" \ "field").extractOpt[String]
+        } yield {
+            field
+        }
+    }
+
+    def apply(json: JValue): Option[Props] = {
+        getParams(json).map(_ => Props(classOf[UnlistActor], json))
+    }
+}
+
+class UnlistActor(json: JObject) extends CoralActor with ActorLogging {
+    def jsonDef = json
+    def state = Map.empty
+    def timer = notSet
+
+    val field = UnlistActor.getParams(json).get
+
+    def trigger = {
+        json: JObject =>
+            val array = (json \ field).asInstanceOf[JArray]
+
+            array.arr.foreach(element => {
+                actorRefFactory.system.scheduler.schedule(0 millis, 0 millis) {
+                    //transmit(emit(element))
+                }
+            })
+
+            OptionT.some(Future.successful({}))
+    }
+
+    def emit = {
+        json: JObject =>
+
+    }
+}

--- a/runtime-api/src/main/scala/io/coral/api/ApiService.scala
+++ b/runtime-api/src/main/scala/io/coral/api/ApiService.scala
@@ -47,7 +47,7 @@ trait ApiService extends HttpService {
           pathEnd {
             get {
               import JsonConversions._
-              ctx => askActor(coralActor,List).mapTo[List[Long]]
+              ctx => askActor(coralActor,ListActors()).mapTo[List[Long]]
                 .onSuccess { case actors => ctx.complete(actors)}
             } ~
               post {

--- a/runtime-api/src/main/scala/io/coral/api/Boot.scala
+++ b/runtime-api/src/main/scala/io/coral/api/Boot.scala
@@ -21,6 +21,8 @@ object Boot extends App {
   val interface = system.settings.config getString "service.interface"
   val port = system.settings.config getInt "service.port"
 
+  println("Binding to interface " + interface + " and port " + port)
+
   // start a new HTTP server with our service actor as the handler
   IO(Http) ! Http.Bind(service, interface, port)
 }

--- a/runtime-api/src/main/scala/io/coral/coralscript/Collect.scala
+++ b/runtime-api/src/main/scala/io/coral/coralscript/Collect.scala
@@ -1,0 +1,6 @@
+package io.coral.coralscript
+
+case class CollectDeclaration(id: Identifier, params: IdentifierList, block: CollectBlock) extends Statement
+case class CollectBlock(collectFrom: CollectFrom, collectWith: CollectWith)
+case class CollectFrom(name: Identifier)
+case class CollectWith(info: String)

--- a/runtime-api/src/main/scala/io/coral/coralscript/CoralScript.scala
+++ b/runtime-api/src/main/scala/io/coral/coralscript/CoralScript.scala
@@ -11,15 +11,11 @@ case class CoralScript(statements: List[Statement]) {
     var method_defs = mMap.empty[String, MethodDeclaration]
     var trigger_defs = mMap.empty[String, TriggerDeclaration]
     var collect_defs = mMap.empty[String, CollectDeclaration]
+	var condition_defs = mMap.empty[String, TriggerCondition]
 
     // The actual values of the objects
     var events = mMap.empty[String, EventDeclaration]
     var entities = mMap.empty[String, EntityDeclaration]
-    var features = mMap.empty[String, FeatureDeclaration]
-    var actions = mMap.empty[String, TriggerAction]
-    var methods = mMap.empty[String, MethodDeclaration]
-    var triggers = mMap.empty[String, TriggerDeclaration]
-    var collects = mMap.empty[String, CollectDeclaration]
 
     var alreadyParsed = false
 
@@ -69,19 +65,21 @@ case class CoralScript(statements: List[Statement]) {
                 case entity: EntityDeclaration =>
                     entities.put(entity.id.toString, entity)
                 case feature: FeatureDeclaration =>
-                    features.put(feature.id.toString, feature)
+                    feature_defs.put(feature.id.toString, feature)
                 case action: TriggerAction =>
-                    actions.put(action.id.toString, action)
+                    action_defs.put(action.id.toString, action)
                 case method: MethodDeclaration =>
-                    methods.put(method.id.toString, method)
+                    method_defs.put(method.id.toString, method)
                 case trigger: TriggerDeclaration =>
-                    triggers.put(trigger.action.toString, trigger)
+                    trigger_defs.put(trigger.action.toString, trigger)
                 case collect: CollectDeclaration =>
-                    collects.put(collect.id.toString, collect)
+                    collect_defs.put(collect.id.toString, collect)
+				case condition: TriggerCondition =>
+					condition_defs.put(condition.id.toString, condition)
                 case other =>
                     // Separate statements and expressions
                     // not yet processed go here.
-                    other.execute()
+                    //other.execute()
             }
 
             alreadyParsed = true

--- a/runtime-api/src/main/scala/io/coral/coralscript/CoralScript.scala
+++ b/runtime-api/src/main/scala/io/coral/coralscript/CoralScript.scala
@@ -23,7 +23,7 @@ case class CoralScript(statements: List[Statement]) {
 
     var alreadyParsed = false
 
-	def execute() {
+	def prepare() {
         /**
             A CoralScript consists of the following elements:
 
@@ -75,7 +75,7 @@ case class CoralScript(statements: List[Statement]) {
                 case method: MethodDeclaration =>
                     methods.put(method.id.toString, method)
                 case trigger: TriggerDeclaration =>
-                    triggers.put(trigger.action.id.toString, trigger)
+                    triggers.put(trigger.action.toString, trigger)
                 case collect: CollectDeclaration =>
                     collects.put(collect.id.toString, collect)
                 case other =>

--- a/runtime-api/src/main/scala/io/coral/coralscript/CoralScript.scala
+++ b/runtime-api/src/main/scala/io/coral/coralscript/CoralScript.scala
@@ -1,0 +1,92 @@
+package io.coral.coralscript
+
+import scala.collection.mutable.{Map => mMap}
+
+case class CoralScript(statements: List[Statement]) {
+    // The objects as they are defined in the script
+    var event_defs = mMap.empty[String, EventDeclaration]
+    var entity_defs = mMap.empty[String, EntityDeclaration]
+    var feature_defs = mMap.empty[String, FeatureDeclaration]
+    var action_defs = mMap.empty[String, TriggerAction]
+    var method_defs = mMap.empty[String, MethodDeclaration]
+    var trigger_defs = mMap.empty[String, TriggerDeclaration]
+    var collect_defs = mMap.empty[String, CollectDeclaration]
+
+    // The actual values of the objects
+    var events = mMap.empty[String, EventDeclaration]
+    var entities = mMap.empty[String, EntityDeclaration]
+    var features = mMap.empty[String, FeatureDeclaration]
+    var actions = mMap.empty[String, TriggerAction]
+    var methods = mMap.empty[String, MethodDeclaration]
+    var triggers = mMap.empty[String, TriggerDeclaration]
+    var collects = mMap.empty[String, CollectDeclaration]
+
+    var alreadyParsed = false
+
+	def execute() {
+        /**
+            A CoralScript consists of the following elements:
+
+            + Events: serve as declaration of objects to be expected.
+              When they finally arrive, check the received objects against
+              their event definitions. If it does not match or types cannot
+              be converted, throw an exception.
+
+            + Entities: when receiving new events, start adding the
+              fields to the collected entities until now. The join conditions
+              specify which field in which event belongs to which entity.
+
+            + Features: are calculated when all information is available,
+              but could also be recalculated on every new piece of information.
+
+            + Actions: are only executed when triggered by a trigger.
+              Have the same syntax as methods but must return an expression.
+
+            + Methods: are only executed when called by an action or elsewhere.
+              Have the same syntax as actions but are simply a list of statements
+              and do not necessarily have to return an expression.
+
+            + Triggers: are executed when conditions are satisfied.
+              This means that when the variables mentioned in a condition
+              change or new values become available, the trigger needs to
+              be re-evaluated.
+
+            + Collects: are executed when called. Collects only communicate with
+              actors, this means an actor has to be implemented that knows how to
+              collect the information required.
+
+            + Separate statements: are executed immediately and in the order they
+              where declared. They throw an Exception if they run into information
+              which is not yet available.
+         */
+
+        // On every incoming event: check the event and add
+
+        if (!alreadyParsed) {
+            statements.foreach {
+                case event: EventDeclaration =>
+                    events.put(event.id.toString, event)
+                case entity: EntityDeclaration =>
+                    entities.put(entity.id.toString, entity)
+                case feature: FeatureDeclaration =>
+                    features.put(feature.id.toString, feature)
+                case action: TriggerAction =>
+                    actions.put(action.id.toString, action)
+                case method: MethodDeclaration =>
+                    methods.put(method.id.toString, method)
+                case trigger: TriggerDeclaration =>
+                    triggers.put(trigger.action.id.toString, trigger)
+                case collect: CollectDeclaration =>
+                    collects.put(collect.id.toString, collect)
+                case other =>
+                    // Separate statements and expressions
+                    // not yet processed go here.
+                    other.execute()
+            }
+
+            alreadyParsed = true
+        } else {
+
+        }
+	}
+}

--- a/runtime-api/src/main/scala/io/coral/coralscript/CoralScriptParser.scala
+++ b/runtime-api/src/main/scala/io/coral/coralscript/CoralScriptParser.scala
@@ -1,0 +1,270 @@
+package io.coral.coralscript
+
+import scala.util.parsing.combinator.{PackratParsers, JavaTokenParsers}
+import scala.util.parsing.input.CharSequenceReader
+
+object CoralScriptParser extends JavaTokenParsers with PackratParsers {
+	def parse(s: String): CoralScript = {
+		val parseResult = phrase(script)(new PackratReader(new CharSequenceReader(s)))
+
+		parseResult match {
+			case Success(r, n) => r
+			case Failure(r, n) =>
+				println(parseResult)
+				null
+		}
+	}
+
+	type P[+T] = PackratParser[T]
+
+	lazy val script: P[CoralScript] =
+		rep(statement) ^^ { case s => CoralScript(s) }
+
+    /**===== STATEMENT =====*/
+	lazy val statement: P[Statement] =
+		(variable_declaration
+        | event_declaration
+        | entity_declaration
+        | collect_declaration
+        | emit_statement
+        | method_declaration
+        | feature
+        //| trigger_action
+        | trigger_condition
+        | expression
+        | statement_block
+        | if_statement
+        | while_statement
+        | for_statement
+        | "return" ~ expression ^^ { case "return" ~ e => ReturnStatement(e)}
+        | "break" ^^ { case "break" => BreakStatement() }
+        | "continue" ^^ { case "continue" => ContinueStatement() } )
+    lazy val statement_block: P[StatementBlock] =
+        "{" ~ rep(statement) ~ "}" ^^ {
+            case ("{" ~ s ~ "}") => StatementBlock(s)}
+    lazy val if_statement: P[IfStatement] =
+        "if" ~ "(" ~ testing_expression ~ ")" ~ statement ~ "else" ~ statement ^^ {
+            case ("if" ~ "(" ~ condition ~ ")" ~ ifpart ~ "else" ~ elsepart)
+                => IfStatement(condition, ifpart, elsepart)}
+    lazy val while_statement: P[WhileStatement] =
+        "while" ~ "(" ~ testing_expression ~ ")" ~ statement ^^ {
+            case ("while" ~ "(" ~ condition ~ ")" ~ s) => WhileStatement(condition, s) }
+    lazy val for_statement: P[ForStatement] =
+        "for" ~ "(" ~ variable_declaration ~ ";" ~ expression ~ ";" ~ expression ~ ")" ~ statement ^^ {
+            case ("for" ~ "(" ~ declaration ~ ";" ~ middle ~ ";" ~ right ~ ";" ~ s)
+                => ForStatement(declaration, middle, right, s) }
+    lazy val method_declaration: P[MethodDeclaration] =
+        identifier ~ "=" ~ statement_block ^^ {
+            case i ~ "=" ~ b => MethodDeclaration(i, b)}
+
+    /**===== VARIABLE =====*/
+    lazy val variable_declaration: P[VariableDeclaration] =
+        type_specifier ~ variable_declarator ^^ {
+            case (t ~ d) => VariableDeclaration(t, d) }
+    lazy val variable_declarator: P[VariableDeclarator] =
+        identifier ~ "=" ~ expression ^^ {
+            case (id ~ "=" ~ expr) => VariableDeclarator(id, expr)}
+    lazy val identifier: P[Identifier] =
+        ident ^^ { case i => SimpleIdentifier(i)}
+    lazy val nested_json_identifier: P[JsonIdentifier] =
+        repsep(identifier, ".") ^^ { case i => JsonIdentifier(i)}
+
+    /**===== EVENT =====*/
+    lazy val event_declaration: P[EventDeclaration] =
+        "event" ~ identifier ~ "{" ~ event_block ~ "}" ^^ {
+            case ("event" ~ id ~ "{" ~ block ~ "}") => EventDeclaration(id, block)}
+    lazy val event_block: P[EventBlock] =
+        repsep(event_variable, ",") ^^ {
+            case e => EventBlock(e) }
+    lazy val event_variable: P[EventVariable] =
+        identifier ~ ":" ~ type_specifier ^^ {
+            case v ~ ":" ~ t => EventVariable(v, t)}
+    lazy val event_field: P[EventField] =
+        nested_json_identifier ^^ {
+            case i => EventField(i)}
+
+    /**===== ENTITY =====*/
+    lazy val entity_declaration: P[EntityDeclaration] =
+        "entity" ~ identifier ~ "{" ~ entity_block ~ "}" ^^ {
+            case ("entity" ~ id ~ "{" ~ block ~ "}") => EntityDeclaration(id, block) }
+    lazy val entity_block: P[EntityBlock] =
+        rep(entity_variable) ^^ {
+            case v => EntityBlock(v) }
+    lazy val entity_variable: P[EntityVariable] =
+        identifier ~ ":" ~ entity_definition ^^ {
+            case (i ~ ":" ~ d) => EntityVariable(i, d)}
+    lazy val entity_definition: P[EntityDefinition] =
+        entity_object ^^ {
+            case o => EntityDefinition(o)}
+    lazy val entity_object: P[EntityObject] =
+        entity_array | entity_collect | event_field
+    lazy val entity_array: P[EntityArray] =
+        "Array" ~ "[" ~ identifier ~ "]" ^^ {
+            case ("Array" ~ "[" ~ id ~ "]") => EntityArray(id) }
+    lazy val entity_collect: P[EntityCollect] =
+        identifier ~ "(" ~ (identifier_list?) ~ ")" ^^ {
+            case (id ~ "(" ~ list ~ ")") => EntityCollect(id, list.orNull) }
+    lazy val identifier_list: P[IdentifierList] =
+        repsep(identifier, comma) ^^ {
+            case i => IdentifierList(i) }
+
+    /**===== FEATURE =====*/
+    lazy val feature: P[FeatureDeclaration] =
+        "feature" ~ identifier ~ "{" ~ "select" ~ select_statement ~ "}" ^^ {
+            case "feature" ~ id ~ "{" ~ "select" ~ stmt ~ "}" => FeatureDeclaration(id, stmt) }
+    lazy val select_statement: P[SelectStatement] =
+        select_list ~ table_expression ^^ {
+            case list ~ table => SelectStatement(distinct = false, list, table) }
+    lazy val select_list: P[SelectList] =
+        (asterisk ^^ {
+            case a => SelectList(Right(SelectAll())) }
+        | repsep(select_item, comma) ^^ {
+            case i => SelectList(Left(i))})
+    lazy val select_item: P[SelectItem] =
+        builtin_method | identifier ^^ {
+            case i => SelectIdentifier(i)}
+    lazy val builtin_method: P[BuiltinMethod] =
+        builtin_method_name ~ "(" ~ nested_json_identifier ~ ")" ^^ {
+            case name ~ "(" ~ field ~ ")" => BuiltinMethod(name, field)}
+    lazy val table_expression: P[TableExpression] =
+        from_clause ~ (where_clause?) ~ (group_by_clause?) /*~ having_clause? ~ order_clause? ~ window_clause?*/ ^^ {
+            case from ~ where ~ group => TableExpression(from, where.orNull, group.orNull)}
+    lazy val from_clause: P[FromClause] =
+        "from" ~ table_reference_list ^^ {
+            case "from" ~ tables => FromClause(tables)}
+    lazy val where_clause: P[WhereClause] =
+        "where" ~ testing_expression ^^ {
+            case "where" ~ test => WhereClause(test) }
+    lazy val group_by_clause: P[GroupByClause] =
+        "group" ~ "by" ~ repsep(identifier, ",") ^^ {
+            case "group" ~ "by" ~ ids => GroupByClause(ids) }
+    /*
+    lazy val having_clause: P[HavingClause] =
+        "having" ~
+    lazy val order_clause: P[OrderClause] =
+        "order" ~ "by" ~
+    lazy val window_clause: P[WindowClause] =
+        "window" ~
+    */
+    lazy val table_reference_list: P[TableReferenceList] =
+        repsep(table_reference, comma) ^^ {
+            case list => TableReferenceList(list)}
+    lazy val table_reference: P[TableReference] =
+        identifier ~ (as_part?) ^^ {
+            case i ~ as => TableReference(i, as.orNull)}
+    lazy val as_part = "as" ~ table_alias ^^ {
+            case "as" ~ a => a}
+    lazy val table_alias: P[TableAlias] =
+        identifier ^^ {
+            case i => TableAlias(i)}
+
+    /**===== COLLECT =====*/
+    lazy val collect_declaration: P[CollectDeclaration] =
+        "collect" ~ identifier ~ "(" ~ (identifier_list?) ~ ")" ~ "{" ~ collect_block ~ "}" ^^ {
+            case "collect" ~ id ~ "(" ~ list ~ ")" ~ "{" ~ block ~ "}"
+                => CollectDeclaration(id, list.orNull, block) }
+    lazy val collect_block: P[CollectBlock] =
+        collect_from ~ "," ~ collect_with ^^ {
+            case f ~ "," ~ w => CollectBlock(f, w)}
+    lazy val collect_from: P[CollectFrom] =
+        "from" ~ ":" ~ identifier ^^ {
+            case "from" ~ ":" ~ id => CollectFrom(id) }
+    lazy val collect_with: P[CollectWith] =
+        "with" ~ ":" ~ string_literal ^^ {
+            case "with" ~ ":" ~ s => CollectWith(s) }
+
+    /**===== EMIT =====*/
+    lazy val emit_statement: P[EmitStatement] =
+        "emit" ~ emit_json ^^ {
+            case ("emit" ~ json) => EmitStatement(json) }
+    lazy val emit_json: P[EmitJson] =
+        "{" ~ repsep(emit_json_field, ",") ~ "}" ^^ {
+            case ("{" ~ fields ~ "}") => EmitJson(fields)}
+    lazy val emit_json_field: P[EmitJsonField] =
+        string_literal ~ ":" ~ emit_json_value ^^ {
+            case (id ~ ":" ~ expr) => EmitJsonField(SimpleIdentifier(id), expr)}
+    lazy val emit_json_value: P[EmitJsonValue] =
+        (string_literal
+        | boolean_literal
+        | integer_literal
+        | float_literal
+        | nested_json_identifier
+        | expression
+        | identifier) ^^ {
+            case value => EmitJsonValue(value) }
+
+    /**===== TRIGGER =====*/
+    lazy val trigger: P[TriggerDeclaration] =
+        "trigger" ~ trigger_action ~ "on" ~ trigger_condition ^^ {
+            case "trigger" ~ a ~ "on" ~ c => TriggerDeclaration(a, c) }
+    lazy val trigger_action: P[TriggerAction] =
+        "action" ~ identifier ~ "=" ~ "{" ~ rep(trigger_statement) ~ "}" ^^ {
+            case "action" ~ id ~ "=" ~ "{" ~ statements ~ "}" => TriggerAction(id, statements)}
+    lazy val trigger_condition: P[TriggerCondition] =
+        "condition" ~ identifier ~ "=" ~ condition_block ^^ {
+            case "condition" ~ id ~ "=" ~ b => TriggerCondition(id, b) }
+    lazy val condition_block: P[ConditionBlock] =
+        "{" ~ rep(trigger_statement) ~ "}" ^^ {
+            case "{" ~ s ~ "}" => ConditionBlock(s)}
+    lazy val trigger_statement: P[TriggerStatement] =
+        (variable_declaration
+        | expression
+        | if_statement
+        | while_statement
+        | for_statement) ^^ {
+            case s => TriggerStatement(s)}
+
+    /**===== EXPRESSION =====*/
+	lazy val expression: P[Expression] =
+		(numeric_expression
+        | testing_expression
+        | literal_expression
+        | out_expression
+        | identifier
+        | ("(" ~ expression  ~ ")") ^^ {
+            case ("(" ~ e ~ ")") => e })
+	lazy val numeric_expression: P[NumericExpression] =
+		("-" ~ numeric_expression ^^ {
+            case (min ~ right) => NegationExpression(right) }
+	    | expression ~ ("++" | "--") ^^ {
+            case (left ~ incr) => IncrementExpression(left, incr) }
+		| expression ~ ("+" | "+=" | "-" | "-=" | "*" | "*=" | "/" | "/=") ~ expression ^^ {
+            case (left ~ op ~ right) => StandardNumericExpression(left, op, right) })
+	lazy val testing_expression: P[TestingExpression] =
+		(expression ~ (">" | "<" | ">=" | "<=" | "==" | "!=") ~ expression ^^ {
+            case (left ~ test ~ right) => TestingExpression(left, test, right) }
+		| expression ~ ("&&" | "||") ~ expression ^^ {
+            case (left ~ op ~ right) => TestingExpression(left, op, right) })
+	lazy val literal_expression: P[LiteralExpression] =
+		(float_literal ^^ {
+            case f => FloatLiteralExpression(f.toFloat) }
+		| integer_literal ^^ {
+            case i => IntegerLiteralExpression(i.toInt)}
+		| stringLiteral ^^ {
+            case s => StringLiteralExpression(s) })
+    lazy val out_expression: P[OutExpression] =
+        "out" ~ variable_declaration ^^ {
+            case ("out" ~ aa) => OutExpression(aa)}
+
+    /**===== LITERALS =====*/
+	lazy val integer_literal = wholeNumber
+	lazy val float_literal = """-?\d+\.\d+""".r
+	lazy val string_literal = stringLiteral
+    lazy val boolean_literal = "true" | "false"
+    lazy val type_specifier =
+        ("Boolean"
+        | "Int"
+        | "Float"
+        | "Long"
+        | "String"
+        | "DateTime")
+    lazy val builtin_method_name =
+        ("avg"
+        | "max"
+        | "min"
+        | "sum"
+        | "count")
+    lazy val comma = ","
+    lazy val distinct = "distinct"
+    lazy val asterisk = "*"
+}

--- a/runtime-api/src/main/scala/io/coral/coralscript/CoralScriptParser.scala
+++ b/runtime-api/src/main/scala/io/coral/coralscript/CoralScriptParser.scala
@@ -1,143 +1,183 @@
 package io.coral.coralscript
 
-import scala.util.parsing.combinator.{PackratParsers, JavaTokenParsers}
+import scala.util.parsing.combinator.{JavaTokenParsers, PackratParsers}
 import scala.util.parsing.input.CharSequenceReader
 
 object CoralScriptParser extends JavaTokenParsers with PackratParsers {
-	def parse(s: String): CoralScript = {
-		val parseResult = phrase(script)(new PackratReader(new CharSequenceReader(s)))
+    def parse(s: String): CoralScript = {
+        val parseResult = phrase(script)(new PackratReader(new CharSequenceReader(s)))
 
-		parseResult match {
-			case Success(r, n) => r
-			case Failure(r, n) =>
-				println(parseResult)
-				null
-		}
-	}
+        parseResult match {
+            case Success(r, n) => r
+            case Failure(r, n) =>
+                println(parseResult)
+                null
+        }
+    }
 
-	type P[+T] = PackratParser[T]
+    type P[+T] = PackratParser[T]
 
-	lazy val script: P[CoralScript] =
-		rep(statement) ^^ { case s => CoralScript(s) }
+    lazy val script: P[CoralScript] =
+        rep(statement) ^^ { case s => CoralScript(s)}
 
-    /**===== STATEMENT =====*/
-	lazy val statement: P[Statement] =
-		(trigger_action
-        | trigger_condition
-        | variable_declaration
-        | event_declaration
-        | entity_declaration
-        | collect_declaration
-        | if_statement
-        | while_statement
-        | for_statement
-        | emit_statement
-        | method_declaration
-        | feature
-        | statement_block
-        | expression
-        | "return" ~ expression ^^ { case "return" ~ e => ReturnStatement(e)}
-        | "break" ^^ { case "break" => BreakStatement() }
-        | "continue" ^^ { case "continue" => ContinueStatement() } )
+    /** ===== STATEMENT ===== */
+    lazy val statement: P[Statement] =
+        (trigger_action
+            | trigger_condition
+            | trigger_declaration
+            | variable_declaration
+            | event_declaration
+            | entity_declaration
+            | collect_declaration
+            | assignment
+            | if_statement
+            | while_statement
+            | for_statement
+            | emit_statement
+            | method_declaration
+            | feature
+            | statement_block
+            | "return" ~ expression ^^ { case "return" ~ e => ReturnStatement(e)}
+            | "break" ^^ { case "break" => BreakStatement()}
+            | "continue" ^^ { case "continue" => ContinueStatement()})
     lazy val statement_block: P[StatementBlock] =
         "{" ~ rep(statement) ~ "}" ^^ {
-            case ("{" ~ s ~ "}") => StatementBlock(s)}
+            case ("{" ~ s ~ "}") => StatementBlock(s)
+        }
     lazy val if_statement: P[IfStatement] =
         "if" ~ "(" ~ testing_expression ~ ")" ~ statement ~ "else" ~ statement ^^ {
             case ("if" ~ "(" ~ condition ~ ")" ~ ifpart ~ "else" ~ elsepart)
-                => IfStatement(condition, ifpart, elsepart)}
+            => IfStatement(condition, ifpart, elsepart)
+        }
     lazy val while_statement: P[WhileStatement] =
         "while" ~ "(" ~ testing_expression ~ ")" ~ statement_block ^^ {
             case ("while" ~ "(" ~ condition ~ ")" ~ s) =>
-                WhileStatement(condition, s) }
+                WhileStatement(condition, s)
+        }
     lazy val for_statement: P[ForStatement] =
         "for" ~ "(" ~ variable_declaration ~ ";" ~ expression ~ ";" ~ expression ~ ")" ~ statement ^^ {
             case ("for" ~ "(" ~ declaration ~ ";" ~ middle ~ ";" ~ right ~ ";" ~ s)
-                => ForStatement(declaration, middle, right, s) }
+            => ForStatement(declaration, middle, right, s)
+        }
     lazy val method_declaration: P[MethodDeclaration] =
         identifier ~ "=" ~ statement_block ^^ {
-            case i ~ "=" ~ b => MethodDeclaration(i, b)}
+            case i ~ "=" ~ b => MethodDeclaration(i, b)
+        }
+    lazy val assignment: P[Assignment] =
+        identifier ~ "=" ~ expression ^^ {
+            case i ~ "=" ~ expr => Assignment(i, expr)
+        }
 
-    /**===== VARIABLE =====*/
+    /** ===== VARIABLE ===== */
     lazy val variable_declaration: P[VariableDeclaration] =
         type_specifier ~ variable_declarator ^^ {
-            case (t ~ d) => VariableDeclaration(t, d) }
+            case (t ~ d) => VariableDeclaration(t, d)
+        }
     lazy val variable_declarator: P[VariableDeclarator] =
         identifier ~ "=" ~ expression ^^ {
-            case (id ~ "=" ~ expr) => VariableDeclarator(id, expr)}
+            case (id ~ "=" ~ expr) => VariableDeclarator(id, expr)
+        }
     lazy val identifier: P[Identifier] =
-        (repsep(ident, ".") ^^ { case i => Identifier(i) }
-        | ident ^^ { case i => println(i); Identifier(List(i)) })
+        (repsep(ident, ".") ^^ { case i => Identifier(i)}
+            | ident ^^ { case i if i.nonEmpty => Identifier(List(i))})
 
-    /**===== EVENT =====*/
+    /** ===== EVENT ===== */
     lazy val event_declaration: P[EventDeclaration] =
         "event" ~ identifier ~ "{" ~ event_block ~ "}" ^^ {
-            case ("event" ~ id ~ "{" ~ block ~ "}") => EventDeclaration(id, block)}
+            case ("event" ~ id ~ "{" ~ block ~ "}") => EventDeclaration(id, block)
+        }
     lazy val event_block: P[EventBlock] =
         repsep(event_variable, ",") ^^ {
-            case e => EventBlock(e) }
+            case e => EventBlock(e)
+        }
     lazy val event_variable: P[EventVariable] =
         identifier ~ ":" ~ type_specifier ^^ {
-            case v ~ ":" ~ t => EventVariable(v, t)}
+            case v ~ ":" ~ t => EventVariable(v, t)
+        }
     lazy val event_field: P[EventField] =
         identifier ^^ {
-            case i => EventField(i)}
+            case i => EventField(i)
+        }
 
-    /**===== ENTITY =====*/
+    /** ===== ENTITY ===== */
     lazy val entity_declaration: P[EntityDeclaration] =
         "entity" ~ identifier ~ "{" ~ entity_block ~ "}" ^^ {
-            case ("entity" ~ id ~ "{" ~ block ~ "}") => EntityDeclaration(id, block) }
+            case ("entity" ~ id ~ "{" ~ block ~ "}") => EntityDeclaration(id, block)
+        }
     lazy val entity_block: P[EntityBlock] =
         rep(entity_variable) ^^ {
-            case v => EntityBlock(v) }
+            case v => EntityBlock(v)
+        }
     lazy val entity_variable: P[EntityVariable] =
         identifier ~ ":" ~ entity_definition ^^ {
-            case (i ~ ":" ~ d) => EntityVariable(i, d)}
+            case (i ~ ":" ~ d) => EntityVariable(i, d)
+        }
     lazy val entity_definition: P[EntityDefinition] =
         entity_object ^^ {
-            case o => EntityDefinition(o)}
+            case o => EntityDefinition(o)
+        }
     lazy val entity_object: P[EntityObject] =
         entity_array | entity_collect | event_field
     lazy val entity_array: P[EntityArray] =
         "Array" ~ "[" ~ identifier ~ "]" ^^ {
-            case ("Array" ~ "[" ~ id ~ "]") => EntityArray(id) }
+            case ("Array" ~ "[" ~ id ~ "]") => EntityArray(id)
+        }
     lazy val entity_collect: P[EntityCollect] =
-        identifier ~ "(" ~ (identifier_list?) ~ ")" ^^ {
-            case (id ~ "(" ~ list ~ ")") => EntityCollect(id, list.orNull) }
+        method_call ^^ {
+            case call => EntityCollect(call)
+        }
     lazy val identifier_list: P[IdentifierList] =
         repsep(identifier, comma) ^^ {
-            case i => IdentifierList(i) }
+            case i => i match {
+                case List(Identifier(Nil)) => IdentifierList(List())
+                case _ => IdentifierList(i)
+            }
+        }
+    lazy val parameter_list: P[IdentifierList] =
+        "(" ~ (identifier_list ?) ~ ")" ^^ {
+            case "(" ~ l ~ ")" => l.get
+        }
 
-    /**===== FEATURE =====*/
+    /** ===== FEATURE ===== */
     lazy val feature: P[FeatureDeclaration] =
         "feature" ~ identifier ~ "{" ~ "select" ~ select_statement ~ "}" ^^ {
-            case "feature" ~ id ~ "{" ~ "select" ~ stmt ~ "}" => FeatureDeclaration(id, stmt) }
+            case "feature" ~ id ~ "{" ~ "select" ~ stmt ~ "}" => FeatureDeclaration(id, stmt)
+        }
     lazy val select_statement: P[SelectStatement] =
         select_list ~ table_expression ^^ {
-            case list ~ table => SelectStatement(distinct = false, list, table) }
+            case list ~ table => SelectStatement(distinct = false, list, table)
+        }
     lazy val select_list: P[SelectList] =
         (asterisk ^^ {
-            case a => SelectList(Right(SelectAll())) }
-        | repsep(select_item, comma) ^^ {
-            case i => SelectList(Left(i))})
+            case a => SelectList(Right(SelectAll()))
+        }
+            | repsep(select_item, comma) ^^ {
+            case i => SelectList(Left(i))
+        })
     lazy val select_item: P[SelectItem] =
         builtin_method | identifier ^^ {
-            case i => SelectIdentifier(i)}
+            case i => SelectIdentifier(i)
+        }
     lazy val builtin_method: P[BuiltinMethod] =
         builtin_method_name ~ "(" ~ identifier ~ ")" ^^ {
-            case name ~ "(" ~ field ~ ")" => BuiltinMethod(name, field)}
+            case name ~ "(" ~ field ~ ")" => BuiltinMethod(name, field)
+        }
     lazy val table_expression: P[TableExpression] =
-        from_clause ~ (where_clause?) ~ (group_by_clause?) /*~ having_clause? ~ order_clause? ~ window_clause?*/ ^^ {
-            case from ~ where ~ group => TableExpression(from, where.orNull, group.orNull)}
+        from_clause ~ (where_clause ?) ~ (group_by_clause ?) /*~ having_clause? ~ order_clause? ~ window_clause?*/ ^^ {
+            case from ~ where ~ group => TableExpression(from, where.orNull, group.orNull)
+        }
     lazy val from_clause: P[FromClause] =
         "from" ~ table_reference_list ^^ {
-            case "from" ~ tables => FromClause(tables)}
+            case "from" ~ tables => FromClause(tables)
+        }
     lazy val where_clause: P[WhereClause] =
         "where" ~ testing_expression ^^ {
-            case "where" ~ test => WhereClause(test) }
+            case "where" ~ test => WhereClause(test)
+        }
     lazy val group_by_clause: P[GroupByClause] =
         "group" ~ "by" ~ repsep(identifier, ",") ^^ {
-            case "group" ~ "by" ~ ids => GroupByClause(ids) }
+            case "group" ~ "by" ~ ids => GroupByClause(ids)
+        }
     /*
     lazy val having_clause: P[HavingClause] =
         "having" ~
@@ -148,122 +188,149 @@ object CoralScriptParser extends JavaTokenParsers with PackratParsers {
     */
     lazy val table_reference_list: P[TableReferenceList] =
         repsep(table_reference, comma) ^^ {
-            case list => TableReferenceList(list)}
+            case list => TableReferenceList(list)
+        }
     lazy val table_reference: P[TableReference] =
-        identifier ~ (as_part?) ^^ {
-            case i ~ as => TableReference(i, as.orNull)}
+        identifier ~ (as_part ?) ^^ {
+            case i ~ as => TableReference(i, as.orNull)
+        }
     lazy val as_part = "as" ~ table_alias ^^ {
-            case "as" ~ a => a}
+        case "as" ~ a => a
+    }
     lazy val table_alias: P[TableAlias] =
         identifier ^^ {
-            case i => TableAlias(i)}
+            case i => TableAlias(i)
+        }
 
-    /**===== COLLECT =====*/
+    /** ===== COLLECT ===== */
     lazy val collect_declaration: P[CollectDeclaration] =
-        "collect" ~ identifier ~ "(" ~ (identifier_list?) ~ ")" ~ "{" ~ collect_block ~ "}" ^^ {
-            case "collect" ~ id ~ "(" ~ list ~ ")" ~ "{" ~ block ~ "}"
-                => CollectDeclaration(id, list.orNull, block) }
+        "collect" ~ identifier ~ parameter_list ~ "{" ~ collect_block ~ "}" ^^ {
+            case "collect" ~ id ~ list ~ "{" ~ block ~ "}" => CollectDeclaration(id, list, block)
+        }
     lazy val collect_block: P[CollectBlock] =
         collect_from ~ collect_with ^^ {
-            case f ~ w => CollectBlock(f, w)}
+            case f ~ w => CollectBlock(f, w)
+        }
     lazy val collect_from: P[CollectFrom] =
         "from" ~ ":" ~ identifier ^^ {
-            case "from" ~ ":" ~ id => CollectFrom(id) }
+            case "from" ~ ":" ~ id => CollectFrom(id)
+        }
     lazy val collect_with: P[CollectWith] =
         "with" ~ ":" ~ string_literal ^^ {
-            case "with" ~ ":" ~ s => CollectWith(s) }
+            case "with" ~ ":" ~ s => CollectWith(s.replace("\"", ""))
+        }
 
-    /**===== EMIT =====*/
+    /** ===== EMIT ===== */
     lazy val emit_statement: P[EmitStatement] =
         "emit" ~ emit_json ^^ {
-            case ("emit" ~ json) => EmitStatement(json) }
+            case ("emit" ~ json) => EmitStatement(json)
+        }
     lazy val emit_json: P[EmitJson] =
         "{" ~ repsep(emit_json_field, ",") ~ "}" ^^ {
-            case ("{" ~ fields ~ "}") => EmitJson(fields)}
+            case ("{" ~ fields ~ "}") => EmitJson(fields)
+        }
     lazy val emit_json_field: P[EmitJsonField] =
         string_literal ~ ":" ~ emit_json_value ^^ {
-            case (id ~ ":" ~ expr) => EmitJsonField(Identifier(List(id)), expr)}
+            case (id ~ ":" ~ expr) => EmitJsonField(Identifier(List(id.replace("\"", ""))), expr)
+        }
     lazy val emit_json_value: P[EmitJsonValue] =
         (string_literal
-        | boolean_literal
-        | integer_literal
-        | float_literal
-        | identifier
-        | expression
-        ) ^^ {
-            case value => EmitJsonValue(value) }
+            | boolean_literal
+            | integer_literal
+            | float_literal
+            | identifier
+            | expression
+            ) ^^ {
+            case value => EmitJsonValue(value)
+        }
 
-    /**===== TRIGGER =====*/
-    lazy val trigger: P[TriggerDeclaration] =
-        "trigger" ~ trigger_action ~ "on" ~ trigger_condition ^^ {
-            case "trigger" ~ a ~ "on" ~ c => TriggerDeclaration(a, c) }
+    /** ===== TRIGGER ===== */
+    lazy val trigger_declaration: P[TriggerDeclaration] =
+        "trigger" ~ identifier ~ "on" ~ identifier ^^ {
+            case "trigger" ~ a ~ "on" ~ c => TriggerDeclaration(a, c)
+        }
     lazy val trigger_action: P[TriggerAction] =
         "action" ~ identifier ~ "=" ~ "{" ~ rep(trigger_statement) ~ "}" ^^ {
             case "action" ~ id ~ "=" ~ "{" ~ statements ~ "}" =>
-                TriggerAction(id, statements)}
+                TriggerAction(id, statements)
+        }
     lazy val trigger_condition: P[TriggerCondition] =
         "condition" ~ identifier ~ "=" ~ condition_block ^^ {
-            case "condition" ~ id ~ "=" ~ b => TriggerCondition(id, b) }
+            case "condition" ~ id ~ "=" ~ b => TriggerCondition(id, b)
+        }
     lazy val condition_block: P[ConditionBlock] =
         "{" ~ rep(trigger_statement) ~ "}" ^^ {
-            case "{" ~ s ~ "}" => ConditionBlock(s)}
+            case "{" ~ s ~ "}" => ConditionBlock(s)
+        }
     lazy val trigger_statement: P[TriggerStatement] =
-        (while_statement
-        | for_statement
-        | if_statement
-        | variable_declaration
-        | expression) ^^ {
-            case s => TriggerStatement(s)}
+        (testing_expression
+            | while_statement
+            | for_statement
+            | if_statement
+            | variable_declaration
+            | emit_statement) ^^ {
+            case s => TriggerStatement(s)
+        }
 
-    /**===== EXPRESSION =====*/
-	lazy val expression: P[Expression] =
-        (identifier
-        | numeric_expression
-        | testing_expression
-        | literal_expression
-        | ("(" ~ expression  ~ ")") ^^ {
-            case ("(" ~ e ~ ")") => e })
-	lazy val numeric_expression: P[NumericExpression] =
-		("-" ~ numeric_expression ^^ {
-            case (min ~ right) => NegationExpression(right) }
-	    | expression ~ ("++" | "--") ^^ {
-            case (left ~ incr) => IncrementExpression(left, incr) }
-		| expression ~ ("+" | "+=" | "-" | "-=" | "*" | "*=" | "/" | "/=") ~ expression ^^ {
-            case (left ~ op ~ right) => StandardNumericExpression(left, op, right) })
-	lazy val testing_expression: P[TestingExpression] =
-		expression ~ (">" | "<" | ">=" | "<=" | "==" | "!=") ~ expression ^^ {
-            case (left ~ test ~ right) => TestingExpression(left, test, right) }
-		/*| expression ~ ("&&" | "||") ~ expression ^^ {
-            case (left ~ op ~ right) => TestingExpression(left, op, right) })*/
-	lazy val literal_expression: P[LiteralExpression] =
-		(float_literal ^^ {
-            case f => FloatLiteralExpression(f.toFloat) }
-		| integer_literal ^^ {
-            case i => IntegerLiteralExpression(i.toInt)}
-		| stringLiteral ^^ {
-            case s => StringLiteralExpression(s) })
-    lazy val out_expression: P[OutExpression] =
-        "out" ~ variable_declaration ^^ {
-            case ("out" ~ aa) => OutExpression(aa)}
+    /** ===== EXPRESSION ===== */
+    lazy val expression: P[Expression] =
+        (numeric_expression
+            | testing_expression
+            | literal_expression
+            | method_call
+            | identifier
+            | ("(" ~ expression ~ ")") ^^ {
+            case ("(" ~ e ~ ")") => e
+        })
+    lazy val numeric_expression: P[NumericExpression] =
+        ("-" ~ numeric_expression ^^ {
+            case (min ~ right) => NegationExpression(right)
+        }
+            | expression ~ ("++" | "--") ^^ {
+            case (left ~ incr) => IncrementExpression(left, incr)
+        }
+            | expression ~ ("+" | "+=" | "-" | "-=" | "*" | "*=" | "/" | "/=") ~ expression ^^ {
+            case (left ~ op ~ right) => StandardNumericExpression(left, op, right)
+        })
+    lazy val testing_expression: P[TestingExpression] =
+        expression ~ (">" | "<" | ">=" | "<=" | "==" | "!=") ~ expression ^^ {
+            case (left ~ test ~ right) => TestingExpression(left, test, right)
+        }
+    /*| expression ~ ("&&" | "||") ~ expression ^^ {
+        case (left ~ op ~ right) => TestingExpression(left, op, right) })*/
+    lazy val literal_expression: P[LiteralExpression] =
+        (float_literal ^^ {
+            case f => FloatLiteralExpression(f.toFloat)
+        }
+            | integer_literal ^^ {
+            case i => IntegerLiteralExpression(i.toInt)
+        }
+            | stringLiteral ^^ {
+            case s => StringLiteralExpression(s)
+        })
+    lazy val method_call: P[MethodCall] =
+        identifier ~ parameter_list ^^ {
+            case i ~ list => MethodCall(i, list)
+        }
 
-    /**===== LITERALS =====*/
-	lazy val integer_literal = wholeNumber
-	lazy val float_literal = """-?\d+\.\d+""".r
-	lazy val string_literal = stringLiteral
+    /** ===== LITERALS ===== */
+    lazy val integer_literal = wholeNumber
+    lazy val float_literal = """-?\d+\.\d+""".r
+    lazy val string_literal = stringLiteral
     lazy val boolean_literal = "true" | "false"
     lazy val type_specifier =
-        ("Boolean"
-        | "Int"
-        | "Float"
-        | "Long"
-        | "String"
-        | "DateTime") ^^ { case x => println(x); x }
+        ("boolean"
+            | "int"
+            | "float"
+            | "long"
+            | "string"
+            | "datetime")
     lazy val builtin_method_name =
         ("avg"
-        | "max"
-        | "min"
-        | "sum"
-        | "count")
+            | "max"
+            | "min"
+            | "sum"
+            | "count")
     lazy val comma = ","
     lazy val distinct = "distinct"
     lazy val asterisk = "*"

--- a/runtime-api/src/main/scala/io/coral/coralscript/Emit.scala
+++ b/runtime-api/src/main/scala/io/coral/coralscript/Emit.scala
@@ -4,8 +4,4 @@ case class EmitJson(fields: List[EmitJsonField])
 case class EmitJsonField(id: Identifier, expr: EmitJsonValue)
 case class EmitJsonValue(value: Any)
 
-case class EmitStatement(json: EmitJson) extends Statement {
-    override def execute() {
-
-    }
-}
+case class EmitStatement(json: EmitJson) extends Statement

--- a/runtime-api/src/main/scala/io/coral/coralscript/Emit.scala
+++ b/runtime-api/src/main/scala/io/coral/coralscript/Emit.scala
@@ -1,0 +1,11 @@
+package io.coral.coralscript
+
+case class EmitJson(fields: List[EmitJsonField])
+case class EmitJsonField(id: Identifier, expr: EmitJsonValue)
+case class EmitJsonValue(value: Any)
+
+case class EmitStatement(json: EmitJson) extends Statement {
+    override def execute() {
+
+    }
+}

--- a/runtime-api/src/main/scala/io/coral/coralscript/Entity.scala
+++ b/runtime-api/src/main/scala/io/coral/coralscript/Entity.scala
@@ -5,14 +5,15 @@ case class EntityArray(id: Identifier) extends EntityObject
 case class EntityCollect(call: MethodCall) extends EntityObject
 case class IdentifierList(list: List[Identifier]) extends EntityObject
 case class EntityBlock(block: List[EntityVariable])
-case class EntityDefinition(obj: EntityObject)
-case class EntityVariable(id: Identifier, definition: EntityDefinition)
+case class EntityKey(id: Identifier)
+case class EntityDefinition(obj: EntityObject) {
+    println("entity definition")
+}
+case class EntityVariable(id: Identifier, definition: EntityDefinition) {
+    println("entity variable")
+}
 
 case class EntityDeclaration(id: Identifier, block: EntityBlock) extends Statement {
-    override def execute() {
-
-    }
-
     /**
      * Retrieve the key field for a given entity. The key field
      * is the field that is used to link all other fields together.

--- a/runtime-api/src/main/scala/io/coral/coralscript/Entity.scala
+++ b/runtime-api/src/main/scala/io/coral/coralscript/Entity.scala
@@ -2,7 +2,7 @@ package io.coral.coralscript
 
 abstract class EntityObject
 case class EntityArray(id: Identifier) extends EntityObject
-case class EntityCollect(id: Identifier, list: IdentifierList) extends EntityObject
+case class EntityCollect(call: MethodCall) extends EntityObject
 case class IdentifierList(list: List[Identifier]) extends EntityObject
 case class EntityBlock(block: List[EntityVariable])
 case class EntityDefinition(obj: EntityObject)
@@ -11,5 +11,27 @@ case class EntityVariable(id: Identifier, definition: EntityDefinition)
 case class EntityDeclaration(id: Identifier, block: EntityBlock) extends Statement {
     override def execute() {
 
+    }
+
+    /**
+     * Retrieve the key field for a given entity. The key field
+     * is the field that is used to link all other fields together.
+     * For instance, if key is accountId, then all data that is looked
+     * up for the entity is linked through the same accountId.
+     * @return The name of the key field of the entity.
+     */
+    def getKey: Option[String] = {
+        val key = block.block.find(v => v.id.toString == "key")
+
+        if (key.isDefined) {
+            key.get match {
+                case EntityVariable(_, EntityDefinition(EventField(field))) =>
+                    Some(field.toString)
+                case _ =>
+                    None
+            }
+        } else {
+            None
+        }
     }
 }

--- a/runtime-api/src/main/scala/io/coral/coralscript/Entity.scala
+++ b/runtime-api/src/main/scala/io/coral/coralscript/Entity.scala
@@ -1,0 +1,15 @@
+package io.coral.coralscript
+
+abstract class EntityObject
+case class EntityArray(id: Identifier) extends EntityObject
+case class EntityCollect(id: Identifier, list: IdentifierList) extends EntityObject
+case class IdentifierList(list: List[Identifier]) extends EntityObject
+case class EntityBlock(block: List[EntityVariable])
+case class EntityDefinition(obj: EntityObject)
+case class EntityVariable(id: Identifier, definition: EntityDefinition)
+
+case class EntityDeclaration(id: Identifier, block: EntityBlock) extends Statement {
+    override def execute() {
+
+    }
+}

--- a/runtime-api/src/main/scala/io/coral/coralscript/Event.scala
+++ b/runtime-api/src/main/scala/io/coral/coralscript/Event.scala
@@ -4,8 +4,4 @@ case class EventBlock(block: List[EventVariable])
 case class EventField(id: Identifier) extends EntityObject
 case class EventVariable(id: Identifier, typeSpec: String)
 
-case class EventDeclaration(id: Identifier, block: EventBlock) extends Statement {
-    override def execute() {
-
-    }
-}
+case class EventDeclaration(id: Identifier, block: EventBlock) extends Statement

--- a/runtime-api/src/main/scala/io/coral/coralscript/Event.scala
+++ b/runtime-api/src/main/scala/io/coral/coralscript/Event.scala
@@ -1,7 +1,7 @@
 package io.coral.coralscript
 
 case class EventBlock(block: List[EventVariable])
-case class EventField(id: JsonIdentifier) extends EntityObject
+case class EventField(id: Identifier) extends EntityObject
 case class EventVariable(id: Identifier, typeSpec: String)
 
 case class EventDeclaration(id: Identifier, block: EventBlock) extends Statement {

--- a/runtime-api/src/main/scala/io/coral/coralscript/Event.scala
+++ b/runtime-api/src/main/scala/io/coral/coralscript/Event.scala
@@ -1,0 +1,11 @@
+package io.coral.coralscript
+
+case class EventBlock(block: List[EventVariable])
+case class EventField(id: JsonIdentifier) extends EntityObject
+case class EventVariable(id: Identifier, typeSpec: String)
+
+case class EventDeclaration(id: Identifier, block: EventBlock) extends Statement {
+    override def execute() {
+
+    }
+}

--- a/runtime-api/src/main/scala/io/coral/coralscript/Expression.scala
+++ b/runtime-api/src/main/scala/io/coral/coralscript/Expression.scala
@@ -12,7 +12,9 @@ case class OrExpression(left: Expression, right: Expression) extends Expression
 case class OutExpression(declaration: VariableDeclaration) extends Expression
 case class StandardNumericExpression(left: Expression, op: String, right: Expression) extends NumericExpression
 case class StringLiteralExpression(s: String) extends LiteralExpression
-case class TestingExpression(left: Expression, test: String, right: Expression) extends Expression
+case class TestingExpression(left: Expression, test: String, right: Expression) extends Expression {
+    println("testing expression, left: " + left.toString + ", test: " + test + ", right: " + right.toString)
+}
 
 abstract class Expression extends Statement {
     override def execute() {

--- a/runtime-api/src/main/scala/io/coral/coralscript/Expression.scala
+++ b/runtime-api/src/main/scala/io/coral/coralscript/Expression.scala
@@ -1,24 +1,131 @@
 package io.coral.coralscript
 
-abstract class LiteralExpression extends Expression
-abstract class NumericExpression extends Expression
-case class AndExpression(left: Expression, right: Expression) extends Expression
-case class FloatLiteralExpression(f: Float) extends LiteralExpression
-case class IncrementExpression(expression: Expression, increment: String) extends NumericExpression
-case class IntegerLiteralExpression(i: Int) extends LiteralExpression
-case class NegationExpression(expression: Expression) extends NumericExpression
-case class NumericLiteralExpression() extends Expression
-case class OrExpression(left: Expression, right: Expression) extends Expression
-case class OutExpression(declaration: VariableDeclaration) extends Expression
-case class StandardNumericExpression(left: Expression, op: String, right: Expression) extends NumericExpression
-case class StringLiteralExpression(s: String) extends LiteralExpression
+abstract class LiteralExpression[T] extends Expression[T]
+
+case class FloatLitExpr(f: Float) extends LiteralExpression[FloatLitExpr] {
+	override val evaluate = f
+	def gt(o: FloatLitExpr) = f > o.f
+	def ste(o: FloatLitExpr) = f <= o.f
+	def ne(o: FloatLitExpr) = f != o.f
+	def gte(o: FloatLitExpr) = f >= o.f
+	def st(o: FloatLitExpr) = f < o.f
+	def e(o: FloatLitExpr) = f == o.f
+	def plus(o: FloatLitExpr) = f + o.f
+	def minus(o: FloatLitExpr) = f - o.f
+	def times(o: FloatLitExpr) = f * o.f
+	def divide(o: FloatLitExpr) = f / o.f
+	def or(o: FloatLitExpr) = throw new IllegalArgumentException("ste")
+	def and(o: FloatLitExpr) = throw new IllegalArgumentException("ste")
+}
+
+case class IntLitExpr(i: Int) extends LiteralExpression[IntLitExpr] {
+	override val evaluate = i
+
+	def gt(o: IntLitExpr) = i > o.i
+	def ste(o: IntLitExpr) = i <= o.i
+	def ne(o: IntLitExpr) = i != o.i
+	def gte(o: IntLitExpr) = i >= o.i
+	def st(o: IntLitExpr) = i < o.i
+	def e(o: IntLitExpr) = i == o.i
+	def plus(o: IntLitExpr) = i + o.i
+	def minus(o: IntLitExpr) = i - o.i
+	def times(o: IntLitExpr) = i * o.i
+	def divide(o: IntLitExpr) = i / o.i
+	def or(o: IntLitExpr) = throw new IllegalArgumentException("ste")
+	def and(o: IntLitExpr) = throw new IllegalArgumentException("ste")
+}
+
+case class StrLitExpr(s: String) extends LiteralExpression[StrLitExpr] {
+	override val evaluate = s
+	def gt(o: StrLitExpr) = throw new IllegalArgumentException("gt")
+	def ste(o: StrLitExpr) = throw new IllegalArgumentException("ste")
+	def or(o: StrLitExpr) = throw new IllegalArgumentException("or")
+	def and(o: StrLitExpr) = throw new IllegalArgumentException("and")
+	def ne(o: StrLitExpr) = throw new IllegalArgumentException("ne")
+	def gte(o: StrLitExpr) = throw new IllegalArgumentException("gte")
+	def st(o: StrLitExpr) = throw new IllegalArgumentException("st")
+	def e(o: StrLitExpr) = throw new IllegalArgumentException("e")
+	def plus(o: StrLitExpr) = throw new IllegalArgumentException("plus")
+	def minus(o: StrLitExpr) = throw new IllegalArgumentException("minus")
+	def times(o: StrLitExpr) = throw new IllegalArgumentException("times")
+	def divide(o: StrLitExpr) = throw new IllegalArgumentException("divide")
+}
+
+abstract class NumericExpression[T] extends Expression[T]
+
+case class StandardNumExpr(left: Expression, op: String, right: Expression) extends NumericExpression[StandardNumExpr] {
+	override val evaluate = {
+		op match {
+			case "+" => left.plus(right)
+			case "-" => left.minus(right)
+			case "*" => left.times(right)
+			case "/" => left.divide(right)
+			case other => throw new IllegalArgumentException(other)
+		}
+	}
+}
+
+case class IncExpr(expression: NumericExpression, increment: String) extends NumericExpression {
+	override val evaluate = {
+		increment match {
+			case "++" => expression.plus(IntLitExpr(1))
+			case "--" => expression.minus(IntLitExpr(1))
+			case other => throw new IllegalArgumentException(other)
+		}
+	}
+}
+
+case class NegExpr(expression: Expression) extends NumericExpression {
+	override val evaluate = expression.times(IntLitExpr(-1))
+}
+
+case class AndExpression(left: Expression, right: Expression) extends Expression {
+	override val evaluate = left.and(right)
+}
+
+case class OrExpression(left: Expression, right: Expression) extends Expression {
+	override val evaluate = left.or(right)
+}
+
+case class MethodCall(id: Identifier, list: IdentifierList) extends Expression {
+	override val evaluate = {
+
+	}
+}
+
 case class TestingExpression(left: Expression, test: String, right: Expression) extends Expression {
     println("testing expression, left: " + left.toString + ", test: " + test + ", right: " + right.toString)
+
+	override val evaluate = {
+		test match {
+			case "<" => left.st(right)
+			case "<=" => left.ste(right)
+			case ">" => left.gt(right)
+			case ">=" => left.gte(right)
+			case "!=" => left.ne(right)
+			case "==" => left.e(right)
+			case "&&" => left.and(right)
+			case "||" => left.or(right)
+			case other => throw new IllegalArgumentException(other)
+		}
+	}
 }
-case class MethodCall(id: Identifier, list: IdentifierList) extends Expression
 
-abstract class Expression extends Statement {
-    override def execute() {
+abstract class Expression[T <: Expression] extends Statement {
+	println("Evaluating expression")
 
-    }
+	def evaluate: Any
+
+	def gt(o: T)// = throw new IllegalArgumentException("gt")
+	def ste(o: T)// = throw new IllegalArgumentException("ste")
+	def or(o: T)// = throw new IllegalArgumentException("or")
+	def and(o: T)// = throw new IllegalArgumentException("and")
+	def ne(o: T)// = throw new IllegalArgumentException("ne")
+	def gte(o: T)// = throw new IllegalArgumentException("gte")
+	def st(o: T)// = throw new IllegalArgumentException("st")
+	def e(o: T)// = throw new IllegalArgumentException("e")
+	def plus(o: T)// = throw new IllegalArgumentException("plus")
+	def minus(o: T)// = throw new IllegalArgumentException("minus")
+	def times(o: T)// = throw new IllegalArgumentException("times")
+	def divide(o: T)// = throw new IllegalArgumentException("divide")
 }

--- a/runtime-api/src/main/scala/io/coral/coralscript/Expression.scala
+++ b/runtime-api/src/main/scala/io/coral/coralscript/Expression.scala
@@ -15,6 +15,7 @@ case class StringLiteralExpression(s: String) extends LiteralExpression
 case class TestingExpression(left: Expression, test: String, right: Expression) extends Expression {
     println("testing expression, left: " + left.toString + ", test: " + test + ", right: " + right.toString)
 }
+case class MethodCall(id: Identifier, list: IdentifierList) extends Expression
 
 abstract class Expression extends Statement {
     override def execute() {

--- a/runtime-api/src/main/scala/io/coral/coralscript/Expression.scala
+++ b/runtime-api/src/main/scala/io/coral/coralscript/Expression.scala
@@ -1,0 +1,21 @@
+package io.coral.coralscript
+
+abstract class LiteralExpression extends Expression
+abstract class NumericExpression extends Expression
+case class AndExpression(left: Expression, right: Expression) extends Expression
+case class FloatLiteralExpression(f: Float) extends LiteralExpression
+case class IncrementExpression(expression: Expression, increment: String) extends NumericExpression
+case class IntegerLiteralExpression(i: Int) extends LiteralExpression
+case class NegationExpression(expression: Expression) extends NumericExpression
+case class NumericLiteralExpression() extends Expression
+case class OrExpression(left: Expression, right: Expression) extends Expression
+case class OutExpression(declaration: VariableDeclaration) extends Expression
+case class StandardNumericExpression(left: Expression, op: String, right: Expression) extends NumericExpression
+case class StringLiteralExpression(s: String) extends LiteralExpression
+case class TestingExpression(left: Expression, test: String, right: Expression) extends Expression
+
+abstract class Expression extends Statement {
+    override def execute() {
+
+    }
+}

--- a/runtime-api/src/main/scala/io/coral/coralscript/Feature.scala
+++ b/runtime-api/src/main/scala/io/coral/coralscript/Feature.scala
@@ -1,0 +1,24 @@
+package io.coral.coralscript
+
+abstract class SelectItem
+case class SelectStatement(distinct: Boolean, list: SelectList, table: TableExpression)
+case class BuiltinMethod(method: String, id: Identifier) extends SelectItem
+case class SelectIdentifier(i: Identifier) extends SelectItem
+case class SelectList(list: Either[List[SelectItem], SelectAll]) extends SelectItem
+case class FromClause(tables: TableReferenceList)
+case class GroupByClause(ids: List[Identifier])
+case class HavingClause()
+case class OrderClause()
+case class SelectAll()
+case class TableAlias(i: Identifier)
+case class TableExpression(from: FromClause, where: WhereClause, group: GroupByClause)
+case class TableReference(id: Identifier, alias: TableAlias)
+case class TableReferenceList(list: List[TableReference])
+case class WhereClause(test: TestingExpression)
+case class WindowClause()
+
+case class FeatureDeclaration(id: Identifier, select: SelectStatement) extends Statement {
+    override def execute() {
+
+    }
+}

--- a/runtime-api/src/main/scala/io/coral/coralscript/Feature.scala
+++ b/runtime-api/src/main/scala/io/coral/coralscript/Feature.scala
@@ -17,8 +17,4 @@ case class TableReferenceList(list: List[TableReference])
 case class WhereClause(test: TestingExpression)
 case class WindowClause()
 
-case class FeatureDeclaration(id: Identifier, select: SelectStatement) extends Statement {
-    override def execute() {
-
-    }
-}
+case class FeatureDeclaration(id: Identifier, select: SelectStatement) extends Statement

--- a/runtime-api/src/main/scala/io/coral/coralscript/Statement.scala
+++ b/runtime-api/src/main/scala/io/coral/coralscript/Statement.scala
@@ -6,10 +6,13 @@ case class ForStatement(decl: VariableDeclaration, mid: Expression, right: Expre
 case class IfStatement(condition: TestingExpression, ifPart: Statement, elsePart: Statement) extends Statement
 case class ReturnStatement(expression: Expression) extends Statement
 case class StatementBlock(statements: List[Statement]) extends Statement
-case class WhileStatement(condition: TestingExpression, body: Statement) extends Statement
+case class WhileStatement(condition: TestingExpression, body: Statement) extends Statement {
+    println("while statement, condition: " + condition.toString + ", body: " + body.toString)
+}
 case class MethodDeclaration(id: Identifier, statements: StatementBlock) extends Statement
 
 abstract class Statement {
+
     def execute() {
 
     }

--- a/runtime-api/src/main/scala/io/coral/coralscript/Statement.scala
+++ b/runtime-api/src/main/scala/io/coral/coralscript/Statement.scala
@@ -1,0 +1,16 @@
+package io.coral.coralscript
+
+case class BreakStatement() extends Statement
+case class ContinueStatement() extends Statement
+case class ForStatement(decl: VariableDeclaration, mid: Expression, right: Expression, block: Statement) extends Statement
+case class IfStatement(condition: TestingExpression, ifPart: Statement, elsePart: Statement) extends Statement
+case class ReturnStatement(expression: Expression) extends Statement
+case class StatementBlock(statements: List[Statement]) extends Statement
+case class WhileStatement(condition: TestingExpression, body: Statement) extends Statement
+case class MethodDeclaration(id: Identifier, statements: StatementBlock) extends Statement
+
+abstract class Statement {
+    def execute() {
+
+    }
+}

--- a/runtime-api/src/main/scala/io/coral/coralscript/Statement.scala
+++ b/runtime-api/src/main/scala/io/coral/coralscript/Statement.scala
@@ -10,6 +10,7 @@ case class WhileStatement(condition: TestingExpression, body: Statement) extends
     println("while statement, condition: " + condition.toString + ", body: " + body.toString)
 }
 case class MethodDeclaration(id: Identifier, statements: StatementBlock) extends Statement
+case class Assignment(id: Identifier, expression: Expression) extends Statement
 
 abstract class Statement {
 

--- a/runtime-api/src/main/scala/io/coral/coralscript/Statement.scala
+++ b/runtime-api/src/main/scala/io/coral/coralscript/Statement.scala
@@ -12,9 +12,4 @@ case class WhileStatement(condition: TestingExpression, body: Statement) extends
 case class MethodDeclaration(id: Identifier, statements: StatementBlock) extends Statement
 case class Assignment(id: Identifier, expression: Expression) extends Statement
 
-abstract class Statement {
-
-    def execute() {
-
-    }
-}
+abstract class Statement

--- a/runtime-api/src/main/scala/io/coral/coralscript/Trigger.scala
+++ b/runtime-api/src/main/scala/io/coral/coralscript/Trigger.scala
@@ -1,0 +1,7 @@
+package io.coral.coralscript
+
+case class TriggerCondition(id: Identifier, statements: ConditionBlock) extends Statement
+case class TriggerAction(id: Identifier, statements: List[TriggerStatement])
+case class TriggerDeclaration(action: TriggerAction, condition: TriggerCondition)
+case class ConditionBlock(block: List[TriggerStatement])
+case class TriggerStatement(s: Statement)

--- a/runtime-api/src/main/scala/io/coral/coralscript/Trigger.scala
+++ b/runtime-api/src/main/scala/io/coral/coralscript/Trigger.scala
@@ -1,7 +1,9 @@
 package io.coral.coralscript
 
 case class TriggerCondition(id: Identifier, statements: ConditionBlock) extends Statement
-case class TriggerAction(id: Identifier, statements: List[TriggerStatement])
+case class TriggerAction(id: Identifier, statements: List[TriggerStatement]) extends Statement {
+    println("trigger action, id: " + id.toString + ", statements: " + statements.toString)
+}
 case class TriggerDeclaration(action: TriggerAction, condition: TriggerCondition)
 case class ConditionBlock(block: List[TriggerStatement])
 case class TriggerStatement(s: Statement)

--- a/runtime-api/src/main/scala/io/coral/coralscript/Trigger.scala
+++ b/runtime-api/src/main/scala/io/coral/coralscript/Trigger.scala
@@ -4,6 +4,6 @@ case class TriggerCondition(id: Identifier, statements: ConditionBlock) extends 
 case class TriggerAction(id: Identifier, statements: List[TriggerStatement]) extends Statement {
     println("trigger action, id: " + id.toString + ", statements: " + statements.toString)
 }
-case class TriggerDeclaration(action: TriggerAction, condition: TriggerCondition)
+case class TriggerDeclaration(action: Identifier, condition: Identifier) extends Statement
 case class ConditionBlock(block: List[TriggerStatement])
-case class TriggerStatement(s: Statement)
+case class TriggerStatement(s: Statement) extends Statement

--- a/runtime-api/src/main/scala/io/coral/coralscript/Variable.scala
+++ b/runtime-api/src/main/scala/io/coral/coralscript/Variable.scala
@@ -10,5 +10,9 @@ case class VariableInitializer()
 case class Identifier(i: List[String]) extends Expression {
     println(this.getClass.toString + ": " + i.toString)
 
+	override val evaluate = {
+
+	}
+
     override def toString = i.mkString(".")
 }

--- a/runtime-api/src/main/scala/io/coral/coralscript/Variable.scala
+++ b/runtime-api/src/main/scala/io/coral/coralscript/Variable.scala
@@ -1,12 +1,14 @@
 package io.coral.coralscript
 
-case class JsonIdentifier(names: List[Identifier]) extends Identifier(names.mkString("."))
-case class OutVariable(name: String) extends Identifier(name)
-case class SimpleIdentifier(id: String) extends Identifier(id)
-case class VariableDeclaration(typeSpec: String, declarator: VariableDeclarator) extends Statement
+case class VariableDeclaration(typeSpec: String, declarator: VariableDeclarator) extends Statement {
+    println("variable declaration")
+}
+
 case class VariableDeclarator(identifier: Identifier, initializer: Expression)
 case class VariableInitializer()
 
-abstract class Identifier(i: String) extends Expression {
-    override def toString = i
+case class Identifier(i: List[String]) extends Expression {
+    println(this.getClass.toString + ": " + i.toString)
+
+    override def toString = i.mkString(".")
 }

--- a/runtime-api/src/main/scala/io/coral/coralscript/Variable.scala
+++ b/runtime-api/src/main/scala/io/coral/coralscript/Variable.scala
@@ -1,0 +1,12 @@
+package io.coral.coralscript
+
+case class JsonIdentifier(names: List[Identifier]) extends Identifier(names.mkString("."))
+case class OutVariable(name: String) extends Identifier(name)
+case class SimpleIdentifier(id: String) extends Identifier(id)
+case class VariableDeclaration(typeSpec: String, declarator: VariableDeclarator) extends Statement
+case class VariableDeclarator(identifier: Identifier, initializer: Expression)
+case class VariableInitializer()
+
+abstract class Identifier(i: String) extends Expression {
+    override def toString = i
+}

--- a/runtime-api/src/main/scala/io/coral/coralscript/model/EventData.scala
+++ b/runtime-api/src/main/scala/io/coral/coralscript/model/EventData.scala
@@ -2,5 +2,20 @@ package io.coral.coralscript.model
 
 import scala.collection.mutable.{Map => mMap}
 
+/**
+ * Represents the data of a single event.
+ * In contrast to EventDefinition, this only represents
+ * the data in the object, not the entire structure of the object.
+ * @param id The name if the event
+ * @param data The fields of the event
+ */
 case class EventData(id: String, data: Map[String, Any])
+
+/**
+ * Represents the data of an entity.
+ * For every key, there is one entity.
+ * @param id The name of the entity
+ * @param key The key value of the entity
+ * @param data The data of the entity
+ */
 case class EntityData(id: String, key: String, data: mMap[String, Any])

--- a/runtime-api/src/main/scala/io/coral/coralscript/model/EventData.scala
+++ b/runtime-api/src/main/scala/io/coral/coralscript/model/EventData.scala
@@ -1,0 +1,6 @@
+package io.coral.coralscript.model
+
+import scala.collection.mutable.{Map => mMap}
+
+case class EventData(id: String, data: Map[String, Any])
+case class EntityData(id: String, key: String, data: mMap[String, Any])

--- a/runtime-api/src/test/scala/io/coral/actors/transform/TestUnlistActor.scala
+++ b/runtime-api/src/test/scala/io/coral/actors/transform/TestUnlistActor.scala
@@ -1,0 +1,87 @@
+import akka.actor.{ActorSystem, Props}
+import akka.testkit._
+import akka.util.Timeout
+import io.coral.actors.CoralActorFactory
+import io.coral.actors.Messages.{Shunt, Emit, Trigger}
+import io.coral.actors.transform.{UnlistActor, HttpClientActor}
+import org.json4s._
+import org.json4s.jackson.JsonMethods._
+import org.scalatest.{BeforeAndAfterAll, Matchers, WordSpecLike}
+import akka.pattern.ask
+import scala.concurrent.Await
+import scala.concurrent.duration._
+
+class TestUnlistActor(_system: ActorSystem) extends TestKit(_system)
+    with ImplicitSender
+    with WordSpecLike
+    with Matchers
+    with BeforeAndAfterAll {
+
+    def this() = this(ActorSystem("unlistActor"))
+
+    override def afterAll() {
+        TestKit.shutdownActorSystem(system)
+    }
+
+    implicit val timeout = Timeout(1.seconds)
+
+    "an UnlistActor" should {
+        "Unlist items from a given list" in {
+            val probe = TestProbe()
+            val instantiationJson = parse( """{ "type": "unlist", "params": { "field": "data" } }""").asInstanceOf[JObject]
+            val props: Props = CoralActorFactory.getProps(instantiationJson).get
+            val actorRef = TestActorRef[UnlistActor](props)
+            actorRef.underlyingActor.emitTargets += probe.ref
+
+            val triggerJson = parse(
+                """{ "data": [
+                  | { "name": "object1" },
+                  | { "name": "object2" },
+                  | { "name": "object3" },
+                  | { "name": "object4" }
+                  |] }""".stripMargin).asInstanceOf[JObject]
+
+            actorRef ! Trigger(triggerJson)
+
+            probe.expectMsg(parse("""{ "name": "object1" } """))
+            probe.expectMsg(parse("""{ "name": "object2" } """))
+            probe.expectMsg(parse("""{ "name": "object3" } """))
+            probe.expectMsg(parse("""{ "name": "object4" } """))
+        }
+
+        "Send nothing on an empty list" in {
+            val probe = TestProbe()
+            val instantiationJson = parse( """{ "type": "unlist", "params": { "field": "data" } }""").asInstanceOf[JObject]
+            val props: Props = CoralActorFactory.getProps(instantiationJson).get
+            val actorRef = TestActorRef[UnlistActor](props)
+            actorRef.underlyingActor.emitTargets += probe.ref
+
+            val triggerJson = parse(
+                """{ "data": [] }""".stripMargin).asInstanceOf[JObject]
+
+            actorRef ! Trigger(triggerJson)
+
+            probe.expectNoMsg()
+        }
+
+        "Send nothing on missing data field" in {
+            val probe = TestProbe()
+            val instantiationJson = parse( """{ "type": "unlist", "params": { "field": "data" } }""").asInstanceOf[JObject]
+            val props: Props = CoralActorFactory.getProps(instantiationJson).get
+            val actorRef = TestActorRef[UnlistActor](props)
+            actorRef.underlyingActor.emitTargets += probe.ref
+
+            val triggerJson = parse(
+                """{ "notdata": [
+                  | { "name": "object1" },
+                  | { "name": "object2" },
+                  | { "name": "object3" },
+                  | { "name": "object4" }
+                  |] }""".stripMargin).asInstanceOf[JObject]
+
+            actorRef ! Trigger(triggerJson)
+
+            probe.expectNoMsg()
+        }
+    }
+}

--- a/runtime-api/src/test/scala/io/coral/coralscript/CoralScriptActorSpec.scala
+++ b/runtime-api/src/test/scala/io/coral/coralscript/CoralScriptActorSpec.scala
@@ -11,7 +11,7 @@ import org.json4s.jackson.JsonMethods._
 import org.scalatest.{BeforeAndAfterAll, Matchers, WordSpecLike}
 import scala.concurrent.duration._
 
-class CoralScriptActorSpec (_system: ActorSystem) extends TestKit(_system)
+class CoralScriptActorSpec(_system: ActorSystem) extends TestKit(_system)
     with ImplicitSender
     with WordSpecLike
     with Matchers
@@ -42,22 +42,22 @@ class CoralScriptActorSpec (_system: ActorSystem) extends TestKit(_system)
 
         "Properly parse script1 and act on it" in {
             val script1 = """event Transaction {
-                    transactionId: Long,
-                    accountId: Long,
-                    amount: Float,
-                    datetime: DateTime,
-                    description: String
+                    transactionId: long,
+                    accountId: long,
+                    amount: float,
+                    datetime: datetime,
+                    description: string
                 }
 
                 event BalanceInfo {
-                    accountId: Long,
-                    amount: Float,
-                    datetime: DateTime
+                    accountId: long,
+                    amount: float,
+                    datetime: datetime
                 }
 
                 entity Person {
                     key: accountId
-                    age: collectAge(accountId)
+                    age: collectAge(accountIdValue)
                     transactions: Array[Transaction]
                     currentBalance: BalanceInfo.amount
                 }
@@ -73,12 +73,13 @@ class CoralScriptActorSpec (_system: ActorSystem) extends TestKit(_system)
                     group by day
                 }
 
-                action action1 = {
-                    while (x < 10) {
-                        println(x)
-                    }
+                function action1() {
+					int x = 12
+					while (x < 10) {
+	 					x = x + 1
+	   				}
 
-                    emit { "transactionId": Transaction.transactionId, "outlier": true }
+                    emit ({"transactionId": Transaction.transactionId, "outlier": true })
                 }
 
                 condition condition1 = {

--- a/runtime-api/src/test/scala/io/coral/coralscript/CoralScriptStatementsSpec.scala
+++ b/runtime-api/src/test/scala/io/coral/coralscript/CoralScriptStatementsSpec.scala
@@ -5,12 +5,12 @@ import org.scalatest.FunSuite
 import scala.util.parsing.combinator.PackratParsers
 import scala.util.parsing.input.CharSequenceReader
 
-class TestStatements extends FunSuite with PackratParsers {
+class CoralScriptStatementsSpec extends FunSuite with PackratParsers {
 	test("single assignment") {
 		val script = "int a = 1\n\n"
 		val result = CoralScriptParser.parse(script)
 		assert(result == CoralScript(List(VariableDeclaration("int",
-			VariableDeclarator(SimpleIdentifier("a"), IntegerLiteralExpression(1))))))
+			VariableDeclarator(Identifier(List("a")), IntegerLiteralExpression(1))))))
 	}
 
 	test("multiple assignments") {
@@ -18,8 +18,8 @@ class TestStatements extends FunSuite with PackratParsers {
 
 		val result = CoralScriptParser.parse(script)
 		assert(result == CoralScript(List(VariableDeclaration("float",
-			VariableDeclarator(SimpleIdentifier("a"), FloatLiteralExpression(323.12f))),
-			VariableDeclaration("int", VariableDeclarator(SimpleIdentifier("x"),
+			VariableDeclarator(Identifier(List("a")), FloatLiteralExpression(323.12f))),
+			VariableDeclaration("int", VariableDeclarator(Identifier(List("x")),
 				IntegerLiteralExpression(10))))))
 	}
 
@@ -31,28 +31,28 @@ class TestStatements extends FunSuite with PackratParsers {
 
 		val result = CoralScriptParser.parse(script)
 		assert(result == CoralScript(List(
-			VariableDeclaration("int", VariableDeclarator(SimpleIdentifier("x"), IntegerLiteralExpression(10))),
-			VariableDeclaration("int", VariableDeclarator(SimpleIdentifier("y"), IntegerLiteralExpression(12))),
-			VariableDeclaration("int", VariableDeclarator(SimpleIdentifier("z"), StandardNumericExpression(SimpleIdentifier("x"),
-				"+", StandardNumericExpression(SimpleIdentifier("y"), "*", IntegerLiteralExpression(2))))),
-			OutExpression(VariableDeclaration("int", VariableDeclarator(SimpleIdentifier("bla"),
-				StandardNumericExpression(SimpleIdentifier("z"), "+", IntegerLiteralExpression(3))))))))
+			VariableDeclaration("int", VariableDeclarator(Identifier(List("x")), IntegerLiteralExpression(10))),
+			VariableDeclaration("int", VariableDeclarator(Identifier(List("y")), IntegerLiteralExpression(12))),
+			VariableDeclaration("int", VariableDeclarator(Identifier(List("z")), StandardNumericExpression(Identifier(List("x")),
+				"+", StandardNumericExpression(Identifier(List("y")), "*", IntegerLiteralExpression(2))))),
+			OutExpression(VariableDeclaration("int", VariableDeclarator(Identifier(List("bla")),
+				StandardNumericExpression(Identifier(List("z")), "+", IntegerLiteralExpression(3))))))))
 	}
 
 	test("simple assignments") {
 		val script1 = "int x = 10\n"
 		val result1 = parse(CoralScriptParser.variable_declaration, script1)
-		assert(result1 == VariableDeclaration("int", VariableDeclarator(SimpleIdentifier("x"),
+		assert(result1 == VariableDeclaration("int", VariableDeclarator(Identifier(List("x")),
 			IntegerLiteralExpression(10))))
 
 		val script2 = "int y = 20" // without \n
 		val result2 = parse(CoralScriptParser.variable_declaration, script2)
-		assert(result2 == VariableDeclaration("int", VariableDeclarator(SimpleIdentifier("y"),
+		assert(result2 == VariableDeclaration("int", VariableDeclarator(Identifier(List("y")),
 			IntegerLiteralExpression(20))))
 
 		val script3 = "int z = 10 + 20\n"
 		val result3 = parse(CoralScriptParser.variable_declaration, script3)
-		assert(result3 == VariableDeclaration("int", VariableDeclarator(SimpleIdentifier("z"),
+		assert(result3 == VariableDeclaration("int", VariableDeclarator(Identifier(List("z")),
 			StandardNumericExpression(IntegerLiteralExpression(10),
 				"+", IntegerLiteralExpression(20)))))
 	}
@@ -66,11 +66,11 @@ class TestStatements extends FunSuite with PackratParsers {
 			"   int b = 12\n" +
 			"}"
 		val result = parse(CoralScriptParser.if_statement, script)
-		assert(result == IfStatement(TestingExpression(SimpleIdentifier("x"), "==", IntegerLiteralExpression(10)),
-			StatementBlock(List(VariableDeclaration("int", VariableDeclarator(SimpleIdentifier("y"), IntegerLiteralExpression(20))),
-			VariableDeclaration("int", VariableDeclarator(SimpleIdentifier("z"), StandardNumericExpression(SimpleIdentifier("y"), "+",
+		assert(result == IfStatement(TestingExpression(Identifier(List("x")), "==", IntegerLiteralExpression(10)),
+			StatementBlock(List(VariableDeclaration("int", VariableDeclarator(Identifier(List("y")), IntegerLiteralExpression(20))),
+			VariableDeclaration("int", VariableDeclarator(Identifier(List("z")), StandardNumericExpression(Identifier(List("y")), "+",
 				IntegerLiteralExpression(5)))))),
-			StatementBlock(List(VariableDeclaration("int", VariableDeclarator(SimpleIdentifier("b"),
+			StatementBlock(List(VariableDeclaration("int", VariableDeclarator(Identifier(List("b")),
 				IntegerLiteralExpression(12)))))))
 	}
 

--- a/runtime-api/src/test/scala/io/coral/coralscript/TestCoralScriptActor.scala
+++ b/runtime-api/src/test/scala/io/coral/coralscript/TestCoralScriptActor.scala
@@ -1,0 +1,175 @@
+package io.coral.coralscript
+
+import akka.actor.{Props, ActorSystem}
+import akka.testkit.{TestActorRef, TestProbe, ImplicitSender, TestKit}
+import akka.util.Timeout
+import io.coral.actors.CoralActorFactory
+import io.coral.actors.Messages.Trigger
+import io.coral.actors.transform.{CoralScriptActor, UnlistActor}
+import org.json4s._
+import org.json4s.jackson.JsonMethods._
+import org.scalatest.{BeforeAndAfterAll, Matchers, WordSpecLike}
+import scala.concurrent.duration._
+
+class TestCoralScriptActor (_system: ActorSystem) extends TestKit(_system)
+    with ImplicitSender
+    with WordSpecLike
+    with Matchers
+    with BeforeAndAfterAll {
+    def this() = this(ActorSystem("coralScriptActor"))
+
+    override def afterAll() {
+        TestKit.shutdownActorSystem(system)
+    }
+
+    implicit val timeout = Timeout(1.seconds)
+
+    "a CoralScriptActor" should {
+        "Properly parse script1 and act on it" in {
+            val script1 = """event Transaction {
+                    transactionId: Long,
+                    accountId: Long,
+                    amount: Float,
+                    datetime: DateTime,
+                    description: String
+                }
+
+                event BalanceInfo {
+                    accountId: Long,
+                    amount: Float,
+                    datetime: DateTime
+                }
+
+                entity Person {
+                    key: accountId
+                    age: collectAge(accountId)
+                    transactions: Array[Transaction]
+                    currentBalance: BalanceInfo.amount
+                }
+
+                collect collectAge(accountId) {
+                    from: db1Actor,
+                    with: "select age from customers where accountId = {accountId}"
+                }
+
+                feature avgAmountPerDay {
+                    select avg(Person.transactions.amount)
+                    from Person
+                    group by day
+                }
+
+                action action1 = {
+                    while (x < 10) {
+                        println(x)
+                    }
+
+                    emit { "transactionId": Transaction.transactionId, "outlier": true }
+                }
+
+                condition condition1 = {
+                    Transaction.amount > max(avgAmountPerDay)
+                }
+
+                trigger action1 on condition1
+            """
+
+            val probe = TestProbe()
+            val constructorString =
+                s"""{ "type": "coralscript", "params": { "script":
+                   |${quoteStringForJson(script1)} }}""".stripMargin
+            val constructor = parse(constructorString).asInstanceOf[JObject]
+            val props: Props = CoralActorFactory.getProps(constructor).get
+            val scriptActor = TestActorRef[CoralScriptActor](props)
+            scriptActor.underlyingActor.emitTargets += probe.ref
+
+            val transaction1 = parse("""{
+                    "datatype": "transaction",
+                    "accountId": 1234,
+                    "amount": 54.20,
+                    "datetime": "29-03-2015 18:41:23.582",
+                    "description": "Esso"
+                }""").asInstanceOf[JObject]
+            val transaction2 = parse("""{
+                    "datatype": "transaction",
+                    "accountId": 5678,
+                    "amount": 120.53,
+                    "datetime": "29-03-2015 18:42:23.582",
+                    "description": "Albert Heijn"
+                }""").asInstanceOf[JObject]
+            val balanceInfo1 = parse("""{
+                    "datatype": "balance",
+                    "accountId": 1234,
+                    "amount": 2943.18,
+                    "datetime": "27-03-2015 10:18:12.883"
+                }""").asInstanceOf[JObject]
+            val balanceInfo2 = parse("""{
+                    "datatype": "balance",
+                    "accountId": 1234,
+                    "amount": 2943.18,
+                    "datetime": "27-03-2015 10:18:12.883"
+                }""").asInstanceOf[JObject]
+
+            scriptActor ! Trigger(transaction1)
+            probe.expectNoMsg()
+
+            scriptActor ! Trigger(transaction2)
+            probe.expectNoMsg()
+
+            scriptActor ! Trigger(balanceInfo1)
+            probe.expectNoMsg()
+
+            scriptActor ! Trigger(balanceInfo2)
+
+            val expected = parse("""{
+                    "amount": Person.amount, "average": avgAmountPerDay
+                }""").asInstanceOf[JObject]
+        }
+    }
+
+    def quoteStringForJson(string: String): String = {
+        if (string == null || string.length() == 0) {
+            return "\"\""
+        }
+
+        var c: Char = 0
+        val len: Int = string.length
+        val sb = new StringBuilder(len + 4)
+        var t: String = null
+
+        sb.append('"')
+
+        for (i <- 0 until len) {
+            c = string.charAt(i)
+
+            c match {
+                case '\\' =>
+                case '"' =>
+                    sb.append('\\')
+                    sb.append(c)
+                case '/' =>
+                    sb.append('\\')
+                    sb.append(c)
+                case '\b' =>
+                    sb.append("\\b")
+                case '\t' =>
+                    sb.append("\\t")
+                case '\n' =>
+                    sb.append("\\n")
+                case '\f' =>
+                    sb.append("\\f")
+                case '\r' =>
+                    sb.append("\\r")
+                case _ =>
+                    if (c < ' ') {
+                        t = "000" + Integer.toHexString(c)
+                        sb.append("\\u" + t.substring(t.length() - 4))
+                    } else {
+                        sb.append(c)
+                    }
+            }
+        }
+
+        sb.append('"')
+        sb.toString()
+    }
+}

--- a/runtime-api/src/test/scala/io/coral/coralscript/TestStatements.scala
+++ b/runtime-api/src/test/scala/io/coral/coralscript/TestStatements.scala
@@ -1,0 +1,80 @@
+package io.coral.coralscript
+
+import org.scalatest.FunSuite
+
+import scala.util.parsing.combinator.PackratParsers
+import scala.util.parsing.input.CharSequenceReader
+
+class TestStatements extends FunSuite with PackratParsers {
+	test("single assignment") {
+		val script = "int a = 1\n\n"
+		val result = CoralScriptParser.parse(script)
+		assert(result == CoralScript(List(VariableDeclaration("int",
+			VariableDeclarator(SimpleIdentifier("a"), IntegerLiteralExpression(1))))))
+	}
+
+	test("multiple assignments") {
+		val script = "float a = 323.12\nint x = 10"
+
+		val result = CoralScriptParser.parse(script)
+		assert(result == CoralScript(List(VariableDeclaration("float",
+			VariableDeclarator(SimpleIdentifier("a"), FloatLiteralExpression(323.12f))),
+			VariableDeclaration("int", VariableDeclarator(SimpleIdentifier("x"),
+				IntegerLiteralExpression(10))))))
+	}
+
+	test("script1") {
+		val script = "int x = 10\n" +
+			"int y = 12\n" +
+			"int z = x + y * 2\n" +
+			"out int bla = z + 3\n"
+
+		val result = CoralScriptParser.parse(script)
+		assert(result == CoralScript(List(
+			VariableDeclaration("int", VariableDeclarator(SimpleIdentifier("x"), IntegerLiteralExpression(10))),
+			VariableDeclaration("int", VariableDeclarator(SimpleIdentifier("y"), IntegerLiteralExpression(12))),
+			VariableDeclaration("int", VariableDeclarator(SimpleIdentifier("z"), StandardNumericExpression(SimpleIdentifier("x"),
+				"+", StandardNumericExpression(SimpleIdentifier("y"), "*", IntegerLiteralExpression(2))))),
+			OutExpression(VariableDeclaration("int", VariableDeclarator(SimpleIdentifier("bla"),
+				StandardNumericExpression(SimpleIdentifier("z"), "+", IntegerLiteralExpression(3))))))))
+	}
+
+	test("simple assignments") {
+		val script1 = "int x = 10\n"
+		val result1 = parse(CoralScriptParser.variable_declaration, script1)
+		assert(result1 == VariableDeclaration("int", VariableDeclarator(SimpleIdentifier("x"),
+			IntegerLiteralExpression(10))))
+
+		val script2 = "int y = 20" // without \n
+		val result2 = parse(CoralScriptParser.variable_declaration, script2)
+		assert(result2 == VariableDeclaration("int", VariableDeclarator(SimpleIdentifier("y"),
+			IntegerLiteralExpression(20))))
+
+		val script3 = "int z = 10 + 20\n"
+		val result3 = parse(CoralScriptParser.variable_declaration, script3)
+		assert(result3 == VariableDeclaration("int", VariableDeclarator(SimpleIdentifier("z"),
+			StandardNumericExpression(IntegerLiteralExpression(10),
+				"+", IntegerLiteralExpression(20)))))
+	}
+
+	test("ifstatement1") {
+		val script =
+			"if (x == 10) {\n" +
+			"   int y = 20\n" +
+			"   int z = y + 5\n" +
+			"} else {\n" +
+			"   int b = 12\n" +
+			"}"
+		val result = parse(CoralScriptParser.if_statement, script)
+		assert(result == IfStatement(TestingExpression(SimpleIdentifier("x"), "==", IntegerLiteralExpression(10)),
+			StatementBlock(List(VariableDeclaration("int", VariableDeclarator(SimpleIdentifier("y"), IntegerLiteralExpression(20))),
+			VariableDeclaration("int", VariableDeclarator(SimpleIdentifier("z"), StandardNumericExpression(SimpleIdentifier("y"), "+",
+				IntegerLiteralExpression(5)))))),
+			StatementBlock(List(VariableDeclaration("int", VariableDeclarator(SimpleIdentifier("b"),
+				IntegerLiteralExpression(12)))))))
+	}
+
+	def parse[T <: Statement](subParser: CoralScriptParser.Parser[T], script: String): T = {
+		CoralScriptParser.phrase(subParser)(new PackratReader(new CharSequenceReader(script))).get
+	}
+}


### PR DESCRIPTION
I have created the JsonExpressionParser which evaluates references to local JSON fields. This could be the starting point to extend by also making references to trigger and collect fields possible. 

It currently supports simple field access, nested field access, dictionary access and array access.
simple field access: "fieldname" gets the JValue referred to by fieldname.
nested field access: "field.inner.name" gets the JValue referred to by field.inner.name
dictionary access: "field['inner']" is the same as field.inner
array access: if an array, "field.inner[0]" returns the first element of the inner array.

These can also be combined in arbitrary sequences:
"field.inner[0].other.some['name']"
"field.inner.inner2"
"field[0].inner['name']"
"field['name'].inner[0].value"
"field[0].inner[1]"
