### PR TITLE
Finished JsonExpressionParser for local field references

### DIFF
--- a/project/dependencies.scala
+++ b/project/dependencies.scala
@@ -35,7 +35,7 @@ object Dependencies {
     // dependency injection
     "org.scaldi" %% "scaldi-akka" % "0.5.3",
 
-    "joda-time" % "joda-time" % "2.7"
+    "joda-time" % "joda-time" % "2.7",
     "org.uncommons.maths" % "uncommons-maths" % "1.2.2a",
 
     // persistency

--- a/project/dependencies.scala
+++ b/project/dependencies.scala
@@ -35,7 +35,12 @@ object Dependencies {
     // dependency injection
     "org.scaldi" %% "scaldi-akka" % "0.5.3",
 
-    "org.uncommons.maths" % "uncommons-maths" % "1.2.2a"
+    "joda-time" % "joda-time" % "2.7"
+    "org.uncommons.maths" % "uncommons-maths" % "1.2.2a",
+
+    // persistency
+	"com.github.krasserm" %% "akka-persistence-cassandra" % "0.3.7",
+	"com.typesafe.akka" %% "akka-persistence-experimental" % "2.4-SNAPSHOT"
   )
 
   val allTestDependencies = Seq(

--- a/project/resolvers.scala
+++ b/project/resolvers.scala
@@ -4,7 +4,8 @@ import Keys._
 object Resolvers {
   val allResolvers = Seq (
     "Spray Repository"        at "http://repo.spray.io",
-    "Typesafe Repository"     at "http://repo.typesafe.com/typesafe/releases/"
+    "Typesafe Repository"     at "http://repo.typesafe.com/typesafe/releases/",
+    "krasserm at bintray"     at "http://dl.bintray.com/krasserm/maven"
   )
 }
 

--- a/runtime-api/src/main/resources/application.conf
+++ b/runtime-api/src/main/resources/application.conf
@@ -5,6 +5,8 @@ akka {
   log-dead-letters-during-shutdown = false
 }
 
+akka.persistence.journal.plugin = "cassandra-journal"
+
 service {
   interface = "0.0.0.0"
   port      = 8000

--- a/runtime-api/src/main/scala/io/coral/lib/JsonExpressionParser.scala
+++ b/runtime-api/src/main/scala/io/coral/lib/JsonExpressionParser.scala
@@ -1,0 +1,93 @@
+package io.coral.lib
+
+import org.json4s.{JArray, JValue, JObject}
+import org.json4s.JsonAST.JNothing
+import scala.util.parsing.combinator.{PackratParsers, JavaTokenParsers}
+import scala.util.parsing.input.CharSequenceReader
+
+abstract class FieldElement
+// Represents the complete list of identifiers ("field.array[0].reference['elem']")
+// A FieldReference is a concatenation of FieldElements.
+// A FieldElement is either a simple identifier, an array
+// access element or a dictionary access element.
+case class FieldReference(items: List[FieldElement])
+// Represents a simple identifier between dots
+case class JsonIdentifier(id: String) extends FieldElement
+// Represents an array access identifier ("field[0]")
+case class ArrayAccess(id: JsonIdentifier, index: Int) extends FieldElement
+// Represents a dictionary access identifier ("field['inner']")
+case class DictionaryAccess(id: JsonIdentifier, field: String) extends FieldElement
+
+object JsonExpressionParser extends JavaTokenParsers with PackratParsers {
+	/**
+	 * Parsers an expression string from a JSON field and
+	 * returns the JSON value that the expression points to.
+	 * @param expression The expression to parse.
+	 * @return The JObject that was referred to in the expression
+	 */
+	def parse(expression: String, json: JObject): JValue = {
+		val parseResult = phrase(local_field_reference)(
+			new PackratReader(new CharSequenceReader(expression)))
+
+		parseResult match {
+			case Success(r, n) =>
+				val value = r match {
+					case r: FieldReference => getFieldValue(json, r)
+				}
+
+				value.asInstanceOf[JValue]
+			case Failure(r, n) =>
+				println(parseResult)
+				JNothing
+		}
+	}
+
+	/**
+	 * Returns the value of a field that a FieldReference points to.
+	 * @param json The JSON object to extract the value from
+	 * @param id The FieldReference to extract
+	 * @return The JValue that the FieldReference points to
+	 */
+	def getFieldValue(json: JObject, id: FieldReference): JValue = {
+		// tempJson holds the result we want to return
+		var tempJson: JValue = json
+
+		id.items.foreach({
+			case i: JsonIdentifier =>
+				tempJson = tempJson \ i.id
+			case a: ArrayAccess =>
+				val obj = tempJson \ a.id.id
+				obj match {
+					case array: JArray =>
+						if (a.index < array.arr.length)
+							tempJson = array(a.index)
+						else return JNothing
+					case _ => return JNothing
+				}
+			case d: DictionaryAccess =>
+				tempJson = tempJson \ d.id.id \ d.field
+			case _ =>
+		})
+
+		tempJson
+	}
+
+	type P[+T] = PackratParser[T]
+
+	lazy val local_field_reference: P[FieldReference] =
+		repsep(field_element, ".") ^^ { case i => FieldReference(i)}
+	lazy val field_element: P[FieldElement] =
+		array_access | dictionary_access | json_identifier
+	lazy val json_identifier: P[JsonIdentifier] =
+		ident ^^ { case i => JsonIdentifier(i) }
+	lazy val array_access: P[ArrayAccess] =
+		json_identifier ~ "[" ~ wholeNumber ~ "]" ^^ {
+			case id ~ "[" ~ index ~ "]" =>
+				ArrayAccess(id, index.toInt)
+		}
+	lazy val dictionary_access: P[DictionaryAccess] =
+		json_identifier ~ "[" ~ "'" ~ ident ~ "'" ~ "]" ^^ {
+			case id ~ "[" ~ "'" ~ field ~ "'" ~ "]" =>
+				DictionaryAccess(id, field)
+		}
+}

--- a/runtime-api/src/test/scala/io/coral/lib/JsonExpressionParserSpec.scala
+++ b/runtime-api/src/test/scala/io/coral/lib/JsonExpressionParserSpec.scala
@@ -1,0 +1,279 @@
+package io.coral.lib
+
+import org.scalatest.{Matchers, WordSpecLike}
+import org.json4s._
+import org.json4s.native.JsonMethods._
+
+class JsonExpressionParserSpec extends WordSpecLike with Matchers {
+	implicit val formats = org.json4s.DefaultFormats
+
+	"A JsonExpressionParser" should {
+		"Properly extract array values" in {
+			val expr = "field[0]"
+			val json = parse(
+				"""{ "field": [
+				  	  { "value": "first" },
+	   			      { "value": "second" },
+		 			  { "value": "third" }
+   				     ]
+   				   }""")
+				.asInstanceOf[JObject]
+			val actual = JsonExpressionParser.parse(expr, json)
+			val expected = parse("""{ "value": "first" }""").asInstanceOf[JObject]
+			assert(actual == expected)
+		}
+
+		"Properly extract value from simple field" in {
+			val expr = "field"
+			val json = parse(
+				"""{ "field": [
+				     { "value": "first" },
+				     { "value": "second" },
+				     { "value": "third" }
+				 ]
+			   }""")
+				.asInstanceOf[JObject]
+			val actual = JsonExpressionParser.parse(expr, json)
+			val expected = parse(
+				"""[ { "value": "first" },
+					 { "value": "second" },
+					 { "value": "third" }
+				]""").asInstanceOf[JArray]
+			assert(actual == expected)
+		}
+
+		"Properly extract double from simple field" in {
+			val expr = "field"
+			val json = parse("""{ "field": 2.0 }""")
+				.asInstanceOf[JObject]
+			val actual = JsonExpressionParser.parse(expr, json)
+			val expected = 2.0
+			assert(actual == JDouble(expected))
+		}
+
+		"Properly extract value from nested field" in {
+			val expr = "field.value3.nested"
+			val json = parse(
+				"""{ "field": [
+				  	  { "value1": "first" },
+	   			      { "value2": "second" },
+		 			  { "value3": {
+		 			      "nested": 1,
+		 			      "double": 2.0,
+		 			      "array": [1, 2, 3]
+		 			    }
+		              }
+   				     ]
+   				   }""")
+				.asInstanceOf[JObject]
+			val actual = JsonExpressionParser.parse(expr, json)
+			val expected = JInt(1)
+			assert(actual == expected)
+		}
+
+		"Properly extract fields after an array" in {
+			val expr = "field.inner.array[1].inner2"
+			val json = parse(
+				"""{ "field": [
+				  	  { "value": "first" },
+	   			      { "value": "second" },
+		 			  { "inner": {
+		 			      "nested": 1,
+		 			      "double": 2.0,
+		 			      "array": [
+		 			        { "inner1": "bla" },
+			 			    { "inner2": "value" }
+						  ]
+		 			    }
+		              }
+   				     ]
+   				   }""")
+				.asInstanceOf[JObject]
+			val actual = JsonExpressionParser.parse(expr, json)
+			val expected = JString("value")
+			assert(actual == expected)
+		}
+
+		"Properly extract dictionary names in simple fields" in {
+			val expr = "field['inner']"
+			val json = parse(
+				"""{ "field":
+		 			  { "inner": {
+		 			      "nested": 1,
+		 			      "double": 2.0,
+		 			      "array": [
+		 			        { "inner1": "bla" },
+			 			    { "inner2": "value" }
+						  ]
+		 			    }
+		              }
+				}""").asInstanceOf[JObject]
+			val actual = JsonExpressionParser.parse(expr, json)
+			val expected = parse(
+				"""{
+				    "nested": 1,
+				    "double": 2.0,
+				    "array": [
+				      { "inner1": "bla" },
+				      { "inner2": "value" }
+				    ]
+				  }""")
+			assert(actual == expected)
+		}
+
+		"Properly extract dictionary names after an array" in {
+			val expr = "array[2].inner2['nested']"
+			val json = parse(
+				"""{ "array": [
+				  	  { "value": "first" },
+	   			      { "inner": { "field": 1 }},
+		 			  { "inner2": {
+		 			      "nested": 1,
+		 			      "double": 2.0,
+		 			      "array": [
+		 			        { "inner1": "bla" },
+			 			    { "inner2": "value" }
+						  ]
+		 			    }
+		              }
+   				     ]
+   				   }""")
+				.asInstanceOf[JObject]
+			val actual = JsonExpressionParser.parse(expr, json)
+			val expected = JInt(1)
+			assert(actual == expected)
+		}
+
+		"Properly extract dictionary names after a nested field" in {
+			val expr = "inner.object['field']"
+			val json = parse(
+				"""{ "inner": { "object": { "field": 2.0 }}}""")
+				.asInstanceOf[JObject]
+			val actual = JsonExpressionParser.parse(expr, json)
+			val expected = JDouble(2.0)
+			assert(actual == expected)
+		}
+
+		"Do not extract nonexisting simple field" in {
+			val expr = "doesnotexist"
+			val json = parse("""{ "field": 2.0 }""")
+				.asInstanceOf[JObject]
+			val actual = JsonExpressionParser.parse(expr, json)
+			val expected = JNothing
+			assert(actual == expected)
+		}
+
+		"Do not extract nonexisting nested field" in {
+			val expr = "does.not.exist"
+			val json = parse(
+				"""{ "field": [
+				  	  { "value": "first" },
+	   			      { "value": "second" },
+		 			  { "value": {
+		 			      "nested": 1,
+		 			      "double": 2.0,
+		 			      "array": [1, 2, 3]
+		 			    }
+		              }
+   				     ]
+   				   }""")
+				.asInstanceOf[JObject]
+			val actual = JsonExpressionParser.parse(expr, json)
+			val expected = JNothing
+			assert(actual == expected)
+		}
+
+		"Do not extract array values outside of array bounds" in {
+			val expr = "field[4]"
+			val json = parse(
+				"""{ "field": [
+				  	  { "value": "first" },
+	   			      { "value": "second" },
+		 			  { "value": {
+		 			      "nested": 1,
+		 			      "double": 2.0,
+		 			      "array": [1, 2, 3]
+		 			    }
+		              }
+   				     ]
+   				   }""")
+				.asInstanceOf[JObject]
+			val actual = JsonExpressionParser.parse(expr, json)
+			val expected = JNothing
+			assert(actual == expected)
+		}
+
+		"Do not extract an array access on an element that is not an array" in {
+			val expr = "inner[0]"
+			val json = parse(
+				"""{ "inner": { "object": { "field": 2.0 }}}""")
+				.asInstanceOf[JObject]
+			val actual = JsonExpressionParser.parse(expr, json)
+			val expected = JNothing
+			assert(actual == expected)
+		}
+
+		"Do not extract a dictionary access on an array" in {
+			val expr = "array['field']"
+			val json = parse(
+				"""{ "array": [
+				  	  { "value": "first" },
+	   			      { "inner": { "field": 1 }},
+		 			  { "inner2": {
+		 			      "nested": 1,
+		 			      "double": 2.0,
+		 			      "array": [
+		 			        { "inner1": "bla" },
+			 			    { "inner2": "value" }
+						  ]
+		 			    }
+		              }
+   				     ]
+   				   }""")
+				.asInstanceOf[JObject]
+			val actual = JsonExpressionParser.parse(expr, json)
+			val expected = JNothing
+			assert(actual == expected)
+		}
+
+		"Do not extract nonexisting inner field in expression string" in {
+			val expr = "inner.nonexisting.field"
+			val json = parse(
+				"""{ "inner": { "object": { "field": 2.0 }}}""")
+				.asInstanceOf[JObject]
+			val actual = JsonExpressionParser.parse(expr, json)
+			val expected = JNothing
+			assert(actual == expected)
+		}
+
+		"Do not extract incorrectly formatted expression string" in {
+			val expr = "inner...object]]field']"
+			val json = parse(
+				"""{ "inner": { "object": { "field": 2.0 }}}""")
+				.asInstanceOf[JObject]
+			val actual = JsonExpressionParser.parse(expr, json)
+			val expected = JNothing
+			assert(actual == expected)
+		}
+
+		"Do not extract another incorrectly formatted expression string" in {
+			val expr = "..[][inner..field['blabla']"
+			val json = parse(
+				"""{ "inner": { "object": { "field": 2.0 }}}""")
+				.asInstanceOf[JObject]
+			val actual = JsonExpressionParser.parse(expr, json)
+			val expected = JNothing
+			assert(actual == expected)
+		}
+
+		"Do not extract yet another incorrectly formatted expression string" in {
+			val expr = "inner[0][1].field"
+			val json = parse(
+				"""{ "inner": { "object": { "field": 2.0 }}}""")
+				.asInstanceOf[JObject]
+			val actual = JsonExpressionParser.parse(expr, json)
+			val expected = JNothing
+			assert(actual == expected)
+		}
+	}
+}


### PR DESCRIPTION
I have created the JsonExpressionParser which evaluates references to local JSON fields. This could be the starting point to extend by also making references to trigger and collect fields possible.

It currently supports simple field access, nested field access, dictionary access and array access.
simple field access: "fieldname" gets the JValue referred to by fieldname.
nested field access: "field.inner.name" gets the JValue referred to by field.inner.name
dictionary access: "field['inner']" is the same as field.inner
array access: if an array, "field.inner[0]" returns the first element of the inner array.

These can also be combined in arbitrary sequences:
"field.inner[0].other.some['name']"
"field.inner.inner2"
"field[0].inner['name']"
"field['name'].inner[0].value"
"field[0].inner[1]"
