### PR TITLE
Quit when unable to bind to port

### DIFF
--- a/runtime-api/src/main/scala/io/coral/api/Boot.scala
+++ b/runtime-api/src/main/scala/io/coral/api/Boot.scala
@@ -34,8 +34,8 @@ object Boot extends App {
     case _: Http.Bound => true
     case _ => false
   }
-  val binded = Await.result(future, timeout.duration)
-  if (!binded) {
+  val bounded = Await.result(future, timeout.duration)
+  if (!bounded) {
     System.exit(-1)
   }
 }


### PR DESCRIPTION
When Boot is run, it doesn't quit when it is unable to bind to the configured port. This pull request fixes that.
