### PR TITLE
converted properties from a wrapper to Java properties

### DIFF
--- a/runtime-api/src/main/scala/io/coral/lib/ConfigurationBuilder.scala
+++ b/runtime-api/src/main/scala/io/coral/lib/ConfigurationBuilder.scala
@@ -4,6 +4,8 @@ import java.util.Properties
 
 import com.typesafe.config.{Config, ConfigFactory}
 
+import scala.collection.JavaConverters._
+
 /**
  * Helper class to obtain properties, but have application defined properties already added
  * E.g. Kafka uses java properties for producer and consumer instantiation
@@ -13,22 +15,11 @@ case class ConfigurationBuilder(path: String) {
 
   private lazy val config: Config = ConfigFactory.load.getConfig(path)
 
-  def properties: Properties = new ConfigProperties(config)
-
-}
-
-/**
- * Read properties from configuration and
- * - Make these accessible as Properties
- * - Allow properties to be overwritten
- * @param config base configuration
- */
-private final class ConfigProperties(config: Config) extends Properties() {
-
-  override def getProperty(name: String): String =
-    if (super.containsKey(name)) super.getProperty(name)
-    else config.getString(name)
-
-  override def size = config.entrySet().size + super.size
+  def properties: Properties = {
+    val props = new Properties()
+    val it = config.entrySet().asScala
+    it.foreach { entry => println(s"key=${entry.getKey}, value=${entry.getValue.unwrapped}");props.setProperty(entry.getKey, entry.getValue.unwrapped.toString) }
+    props
+  }
 
 }

--- a/runtime-api/src/main/scala/io/coral/lib/ConfigurationBuilder.scala
+++ b/runtime-api/src/main/scala/io/coral/lib/ConfigurationBuilder.scala
@@ -18,7 +18,7 @@ case class ConfigurationBuilder(path: String) {
   def properties: Properties = {
     val props = new Properties()
     val it = config.entrySet().asScala
-    it.foreach { entry => println(s"key=${entry.getKey}, value=${entry.getValue.unwrapped}");props.setProperty(entry.getKey, entry.getValue.unwrapped.toString) }
+    it.foreach { entry => props.setProperty(entry.getKey, entry.getValue.unwrapped.toString) }
     props
   }
 

--- a/runtime-api/src/test/resources/application.conf
+++ b/runtime-api/src/test/resources/application.conf
@@ -8,5 +8,6 @@ akka {
 test {
   builder {
     someProperty = "someValue"
+    anInteger = 3
   }
 }

--- a/runtime-api/src/test/scala/io/coral/lib/ConfigurationBuilderSpec.scala
+++ b/runtime-api/src/test/scala/io/coral/lib/ConfigurationBuilderSpec.scala
@@ -1,6 +1,5 @@
 package io.coral.lib
 
-import com.typesafe.config.ConfigException
 import org.scalatest.{Matchers, WordSpecLike}
 
 class ConfigurationBuilderSpec extends WordSpecLike with Matchers {
@@ -29,12 +28,10 @@ class ConfigurationBuilderSpec extends WordSpecLike with Matchers {
       properties.getProperty("someProperty") shouldBe "someOtherValue"
     }
 
-    "throw an exception for missing keys" in {
+    "properties (Java) return null for missing keys" in {
       val builder = new ConfigurationBuilder("test.builder")
       val properties = builder.properties
-      intercept[ConfigException] {
-        properties.getProperty("aNonExistingProperty") shouldBe "throwing an exception"
-      }
+      properties.getProperty("aNonExistingProperty") shouldBe null
     }
 
   }

--- a/runtime-api/src/test/scala/io/coral/lib/ConfigurationBuilderSpec.scala
+++ b/runtime-api/src/test/scala/io/coral/lib/ConfigurationBuilderSpec.scala
@@ -10,6 +10,7 @@ class ConfigurationBuilderSpec extends WordSpecLike with Matchers {
       val builder = new ConfigurationBuilder("test.builder")
       val properties = builder.properties
       properties.getProperty("someProperty") shouldBe "someValue"
+      properties.getProperty("anInteger") shouldBe "3"
     }
 
     "allow to add properties" in {
@@ -18,7 +19,7 @@ class ConfigurationBuilderSpec extends WordSpecLike with Matchers {
       properties.setProperty("vis", "blub")
       properties.getProperty("someProperty") shouldBe "someValue"
       properties.getProperty("vis") shouldBe "blub"
-      properties.size shouldBe 2
+      properties.size shouldBe 3
     }
 
     "allow to replace properties" in {


### PR DESCRIPTION
In order to guard against applications calling the map primitives of a properties class
